### PR TITLE
Add HashId logic

### DIFF
--- a/pkg/persistence/db.go
+++ b/pkg/persistence/db.go
@@ -32,7 +32,8 @@ type Conn interface {
 	// less than 14 days ago.
 	FetchKeysForDateNumber(string, uint32, int32) ([]*pb.TemporaryExposureKey, error)
 	StoreKeys(*[32]byte, []*pb.TemporaryExposureKey) error
-	NewKeyClaim(string, string) (string, error)
+	NewKeyClaim(string, string, string) (string, error)
+	CheckHashId(string) (int64, error)
 	ClaimKey(string, []byte) ([]byte, error)
 	PrivForPub([]byte) ([]byte, error)
 
@@ -108,7 +109,7 @@ func (c *conn) ClaimKey(oneTimeCode string, appPublicKey []byte) ([]byte, error)
 
 const maxOneTimeCode = 1e8
 
-func (c *conn) NewKeyClaim(region, originator string) (string, error) {
+func (c *conn) NewKeyClaim(region, originator, hashId string) (string, error) {
 	var err error
 	var n *big.Int
 
@@ -125,7 +126,7 @@ func (c *conn) NewKeyClaim(region, originator string) (string, error) {
 
 		oneTimeCode := fmt.Sprintf("%08d", n)
 
-		err = persistEncryptionKey(c.db, region, originator, pub, priv, oneTimeCode)
+		err = persistEncryptionKey(c.db, region, originator, hashId, pub, priv, oneTimeCode)
 		if err == nil {
 			return oneTimeCode, nil
 		} else if strings.Contains(err.Error(), "Duplicate entry") {
@@ -135,6 +136,10 @@ func (c *conn) NewKeyClaim(region, originator string) (string, error) {
 		}
 	}
 	return "", err
+}
+
+func (c *conn) CheckHashId(hashId string) (int64, error) {
+	return checkHashId(c.db, hashId)
 }
 
 func (c *conn) PrivForPub(pub []byte) ([]byte, error) {

--- a/pkg/persistence/migrator.go
+++ b/pkg/persistence/migrator.go
@@ -76,7 +76,7 @@ CREATE TABLE IF NOT EXISTS failed_key_claim_attempts (
 	}, {
 		id: "4",
 		statements: []string{
-			`ALTER TABLE encryption_keys ADD COLUMN hash_id VARCHAR(64)`,
+			`ALTER TABLE encryption_keys ADD COLUMN hash_id VARCHAR(128)`,
 			`ALTER TABLE encryption_keys ADD INDEX (hash_id)`,
 		},
 	},

--- a/pkg/persistence/migrator.go
+++ b/pkg/persistence/migrator.go
@@ -73,6 +73,12 @@ CREATE TABLE IF NOT EXISTS failed_key_claim_attempts (
 			`ALTER TABLE diagnosis_keys  ADD INDEX (originator)`,
 			`ALTER TABLE encryption_keys ADD INDEX (originator)`,
 		},
+	}, {
+		id: "4",
+		statements: []string{
+			`ALTER TABLE encryption_keys ADD COLUMN hash_id VARCHAR(64)`,
+			`ALTER TABLE encryption_keys ADD INDEX (hash_id)`,
+		},
 	},
 }
 

--- a/pkg/persistence/queries.go
+++ b/pkg/persistence/queries.go
@@ -358,12 +358,34 @@ func checkClaimKeyBan(db queryRower, identifier string) (triesRemaining int, ban
 func checkHashId(db *sql.DB, identifier string) (int64, error) {
 	var count int64
 
-	row := db.QueryRow("SELECT COUNT(*) FROM encryption_keys WHERE hash_id = ?", identifier)
+	row := db.QueryRow("SELECT COUNT(*) FROM encryption_keys WHERE hash_id = ? and one_time_code IS NULL", identifier)
 	err := row.Scan(&count)
 
 	if err != nil {
 		return 1, err
 	}
+
+	// HashId OTC has been used
+	if count > 0 {
+		return count, err
+	}
+
+	row = db.QueryRow("SELECT COUNT(*) FROM encryption_keys WHERE hash_id = ? AND one_time_code IS NOT NULL", identifier)
+	err = row.Scan(&count)
+
+	if err != nil {
+		return 1, err
+	}
+
+	// HashId OTC exists but has not been used
+	if count > 0 {
+		_, err = db.Exec(`DELETE FROM encryption_keys WHERE hash_id = ? AND one_time_code IS NOT NULL`, identifier)
+		if err != nil {
+			return 1, err
+		}
+		count = 0
+	}
+
 
 	return count, err
 }

--- a/pkg/server/keyclaim.go
+++ b/pkg/server/keyclaim.go
@@ -29,7 +29,7 @@ type keyClaimServlet struct {
 
 func (s *keyClaimServlet) RegisterRouting(r *mux.Router) {
 	r.HandleFunc("/new-key-claim", s.newKeyClaim)
-	r.HandleFunc("/new-key-claim/{hashId:[0-9,a-z]{64}}", s.newKeyClaim)
+	r.HandleFunc("/new-key-claim/{hashId:[0-9,a-z]{128}}", s.newKeyClaim)
 	r.HandleFunc("/claim-key", s.claimKeyWrapper)
 }
 

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -10,6 +10,7 @@ require('faraday')
 require('rbnacl')
 require('mysql2')
 require('zip')
+require('securerandom')
 
 KEY_SUBMISSION_SERVER = File.expand_path('../../build/debug/key-submission', __dir__)
 KEY_RETRIEVAL_SERVER = File.expand_path('../../build/debug/key-retrieval', __dir__)
@@ -83,14 +84,19 @@ module Helper
     def diagnosis_originators
       @dbconn.query("SELECT originator FROM encryption_keys").map(&:values).map(&:first)
     end
-      def new_valid_one_time_code
-        resp = @sub_conn.post do |req|
-          req.url('/new-key-claim')
-          req.headers['Authorization'] = 'Bearer first-token'
-        end
-        assert_response(resp, 200, 'text/plain; charset=utf-8')
-        resp.body.chomp
+
+    def random_hash
+      SecureRandom.hex(32)
+    end
+    
+    def new_valid_one_time_code
+      resp = @sub_conn.post do |req|
+        req.url('/new-key-claim')
+        req.headers['Authorization'] = 'Bearer first-token'
       end
+      assert_response(resp, 200, 'text/plain; charset=utf-8')
+      resp.body.chomp
+    end
 
     def new_valid_keyset
       otc = new_valid_one_time_code

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -86,7 +86,7 @@ module Helper
     end
 
     def random_hash
-      SecureRandom.hex(32)
+      SecureRandom.hex(64)
     end
     
     def new_valid_one_time_code

--- a/test/new_key_claim_hash_id_test.rb
+++ b/test/new_key_claim_hash_id_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative('lib/helper')
+
+class NewKeyClaimHashIdTest < MiniTest::Test
+  include(Helper::Include)
+
+  def test_new_key_claim
+    resp = @sub_conn.post do |req|
+      req.url('/new-key-claim/abcd')
+      req.headers['Authorization'] = 'Bearer second-token'
+    end
+    assert_response(resp, 404, 'text/plain; charset=utf-8', body: "404 page not found\n")
+
+    hash_id = random_hash
+
+    %w[get patch delete put].each do |meth|
+      resp = @sub_conn.send(meth, "/new-key-claim/#{hash_id}")
+      assert_response(resp, 405, 'text/plain; charset=utf-8', body: "method not allowed\n")
+    end
+
+    resp = @sub_conn.post do |req|
+      req.url("/new-key-claim/#{hash_id}")
+      req.headers['Authorization'] = 'Bearer second-token'
+    end
+    assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
+    previous_code = resp.body
+
+    # Returns another code if HashId not claimed
+    resp = @sub_conn.post do |req|
+      req.url("/new-key-claim/#{hash_id}")
+      req.headers['Authorization'] = 'Bearer second-token'
+    end
+    assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
+    refute_equal(previous_code, resp.body)
+    valid_code = resp.body
+
+    # Ensure new codes are not generated for claimed HashIds
+    kcq = Covidshield::KeyClaimRequest.new(
+      one_time_code: valid_code.strip,
+      app_public_key: "00001111222233334444555566667710"
+    )
+    resp = @sub_conn.post('/claim-key', kcq.to_proto)
+    assert_response(resp, 200, 'application/x-protobuf')
+    kcr = Covidshield::KeyClaimResponse.decode(resp.body)
+    assert_equal(:NONE, kcr.error)
+    assert_equal(32, kcr.server_public_key.each_byte.size)
+    assert_equal(8, kcr.tries_remaining)
+
+    resp = @sub_conn.post do |req|
+      req.url("/new-key-claim/#{hash_id}")
+      req.headers['Authorization'] = 'Bearer second-token'
+    end
+    assert_response(resp, 401, 'text/plain; charset=utf-8', body: "unauthorized\n")
+
+  end
+end

--- a/test/new_key_claim_test.rb
+++ b/test/new_key_claim_test.rb
@@ -29,27 +29,6 @@ class NewKeyClaimTest < MiniTest::Test
     assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
     assert_equal(['first-token', 'second-token'], encryption_originators)
 
-    resp = @sub_conn.post do |req|
-      req.url('/new-key-claim/abcd')
-      req.headers['Authorization'] = 'Bearer second-token'
-    end
-    assert_response(resp, 404, 'text/plain; charset=utf-8', body: "404 page not found\n")
-
-    hash_id = random_hash
-
-    resp = @sub_conn.post do |req|
-      req.url("/new-key-claim/#{hash_id}")
-      req.headers['Authorization'] = 'Bearer second-token'
-    end
-    assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
-
-    resp = @sub_conn.post do |req|
-      req.url("/new-key-claim/#{hash_id}")
-      req.headers['Authorization'] = 'Bearer second-token'
-    end
-
-    assert_response(resp, 401, 'text/plain; charset=utf-8', body: "unauthorized\n")
-
     %w[get patch delete put].each do |meth|
       resp = @sub_conn.send(meth, '/new-key-claim')
       assert_response(resp, 405, 'text/plain; charset=utf-8', body: "method not allowed\n")

--- a/test/new_key_claim_test.rb
+++ b/test/new_key_claim_test.rb
@@ -29,6 +29,27 @@ class NewKeyClaimTest < MiniTest::Test
     assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
     assert_equal(['first-token', 'second-token'], encryption_originators)
 
+    resp = @sub_conn.post do |req|
+      req.url('/new-key-claim/abcd')
+      req.headers['Authorization'] = 'Bearer second-token'
+    end
+    assert_response(resp, 404, 'text/plain; charset=utf-8', body: "404 page not found\n")
+
+    hash_id = random_hash
+
+    resp = @sub_conn.post do |req|
+      req.url("/new-key-claim/#{hash_id}")
+      req.headers['Authorization'] = 'Bearer second-token'
+    end
+    assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
+
+    resp = @sub_conn.post do |req|
+      req.url("/new-key-claim/#{hash_id}")
+      req.headers['Authorization'] = 'Bearer second-token'
+    end
+
+    assert_response(resp, 401, 'text/plain; charset=utf-8', body: "unauthorized\n")
+
     %w[get patch delete put].each do |meth|
       resp = @sub_conn.send(meth, '/new-key-claim')
       assert_response(resp, 405, 'text/plain; charset=utf-8', body: "method not allowed\n")


### PR DESCRIPTION
There is a scenario where a healthcare provider might like to allow people to issue their own claim codes through a self-serve interface. In this case the user can abuse the system to generate claim codes and sharing those with others, who then use their devices to flood the system with data.

One way to mitigate this is that the self-serve interface attaches a unique 128 character code to the one time token generation url, `/new-key-claim/{hashId:[0-9,a-z]{128}}`. If the same URL is called again and, it checks if the `hashId` exists, and if does and has been claimed, returns a 401. If it does not exist, returns a 200 with a new code. 

The hashId check comes after the Bearer authorization check.

As this is just another URL pattern match, it does not impact users who want use the existing claim functionality. 

**Really important to note**: This will affect the privacy model as it theoretically allows a health unit to track if a user has uploaded their code if you use a deterministic `hashId` - we will need to investigate further on mitigation measures.