### PR TITLE
Added Key stats from database to metrics

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       ECDSA_KEY: 30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a
       KEY_CLAIM_TOKEN: thisisatoken=302
       RETRIEVE_HMAC_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      METRIC_PROVIDER: stdout
     
   db:
     image: mysql:5.7

--- a/cmd/key-retrieval/main.go
+++ b/cmd/key-retrieval/main.go
@@ -15,9 +15,9 @@ func main() {
 
 	log(nil, nil).Info("starting")
 
-	defer telemetry.Initialize().Cleanup()
+	mainApp, db := app.NewBuilder().WithRetrieval().Build()
 
-	mainApp := app.NewBuilder().WithRetrieval().Build()
+	defer telemetry.Initialize(db).Cleanup()
 
 	err := mainApp.RunAndWait()
 	defer log(nil, err).Info("final message before shutdown")

--- a/cmd/key-submission/main.go
+++ b/cmd/key-submission/main.go
@@ -15,9 +15,9 @@ func main() {
 
 	log(nil, nil).Info("starting")
 
-	defer telemetry.Initialize().Cleanup()
+	mainApp, db := app.NewBuilder().WithSubmission().Build()
 
-	mainApp := app.NewBuilder().WithSubmission().Build()
+	defer telemetry.Initialize(db).Cleanup()
 
 	err := mainApp.RunAndWait()
 	defer log(nil, err).Info("final message before shutdown")

--- a/cmd/monolith/main.go
+++ b/cmd/monolith/main.go
@@ -15,9 +15,9 @@ func main() {
 
 	log(nil, nil).Info("starting")
 
-	defer telemetry.Initialize().Cleanup()
+	mainApp, db := app.NewBuilder().WithSubmission().WithRetrieval().Build()
 
-	mainApp := app.NewBuilder().WithSubmission().WithRetrieval().Build()
+	defer telemetry.Initialize(db).Cleanup()
 
 	err := mainApp.RunAndWait()
 	defer log(nil, err).Info("final message before shutdown")

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -66,12 +66,12 @@ func (a *AppBuilder) WithRetrieval() *AppBuilder {
 	return a
 }
 
-func (a *AppBuilder) Build() *App {
+func (a *AppBuilder) Build() (*App, persistence.Conn) {
 	a.components = append(a.components, server.New(bindAddr(a.defaultServerPort), a.servlets))
 
 	main := genmain.New(a.components...)
 	main.SetShutdownDeadline(time.Duration(1) * time.Second)
-	return &App{&main}
+	return &App{&main}, a.database
 }
 
 func DatabaseURL() string {

--- a/pkg/persistence/db.go
+++ b/pkg/persistence/db.go
@@ -44,6 +44,9 @@ type Conn interface {
 	DeleteOldEncryptionKeys() (int64, error)
 	DeleteOldFailedClaimKeyAttempts() (int64, error)
 
+	CountClaimedKeys() (int64, error)
+	CountDiagnosisKeys() (int64, error)
+
 	Close() error
 }
 
@@ -201,6 +204,14 @@ func (c *conn) ClaimKeyFailure(identifier string) (int, time.Duration, error) {
 
 func (c *conn) DeleteOldFailedClaimKeyAttempts() (int64, error) {
 	return deleteOldFailedClaimKeyAttempts(c.db)
+}
+
+func (c *conn) CountClaimedKeys() (int64, error ) {
+	return countClaimedKeys(c.db)
+}
+
+func (c *conn) CountDiagnosisKeys() (int64, error ) {
+	return countDiagnosisKeys(c.db)
 }
 
 func (c *conn) Close() error {

--- a/pkg/persistence/queries.go
+++ b/pkg/persistence/queries.go
@@ -401,3 +401,29 @@ func deleteOldFailedClaimKeyAttempts(db *sql.DB) (int64, error) {
 	}
 	return res.RowsAffected()
 }
+
+func countClaimedKeys(db *sql.DB) (int64, error) {
+	var count int64
+
+	row := db.QueryRow("SELECT COUNT(*) FROM encryption_keys WHERE one_time_code IS NULL")
+	err := row.Scan(&count)
+
+	if err != nil {
+		return -1, err
+	}
+
+	return count, err
+}
+
+func countDiagnosisKeys(db *sql.DB) (int64, error) {
+	var count int64
+
+	row := db.QueryRow("SELECT COUNT(*) FROM diagnosis_keys")
+	err := row.Scan(&count)
+
+	if err != nil {
+		return -1, err
+	}
+
+	return count, err
+}

--- a/pkg/telemetry/stats.go
+++ b/pkg/telemetry/stats.go
@@ -3,6 +3,8 @@ package telemetry
 import (
 	"context"
 
+	"github.com/CovidShield/server/pkg/persistence"
+
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
 	"go.opentelemetry.io/otel/api/global"
@@ -10,7 +12,7 @@ import (
 	"go.opentelemetry.io/otel/api/unit"
 )
 
-func initSystemStatsObserver() {
+func initSystemStatsObserver(db persistence.Conn) {
 	meter := global.Meter("covidshield")
 
 	// Initialize the first CPU measurement so that a percentage will be calculated the next time this method is called
@@ -21,15 +23,21 @@ func initSystemStatsObserver() {
 	var memUsed metric.Int64ValueObserver
 	var memAvailable metric.Int64ValueObserver
 	var cpuPercent metric.Float64ValueObserver
+	var claimedKeysTotalMetric metric.Int64ValueObserver
+	var diagnosisKeysTotalMetric metric.Int64ValueObserver
 
 	cb := metric.Must(meter).NewBatchObserver(func(_ context.Context, result metric.BatchObserverResult) {
 		v, _ := mem.VirtualMemory()
+		claimedKeysTotalMetricCount, _ := db.CountClaimedKeys()
+		diagnosisKeysTotalMetricCount, _ := db.CountDiagnosisKeys()
 		result.Observe(nil,
 			memTotal.Observation(int64(v.Total)),
 			memUsedPercent.Observation(v.UsedPercent),
 			memUsed.Observation(int64(v.Used)),
 			memAvailable.Observation(int64(v.Available)),
 			cpuPercent.Observation(getCPUPercentage()),
+			diagnosisKeysTotalMetric.Observation(diagnosisKeysTotalMetricCount),
+			claimedKeysTotalMetric.Observation(claimedKeysTotalMetricCount),
 		)
 	})
 
@@ -50,6 +58,14 @@ func initSystemStatsObserver() {
 	)
 	cpuPercent = cb.NewFloat64ValueObserver("covidshield.system.cpu.percent",
 		metric.WithDescription("Percentage of all CPUs combined"),
+	)
+
+	claimedKeysTotalMetric = cb.NewInt64ValueObserver("covidshield.app.claimed_keys.total",
+		metric.WithDescription("Total number of claimed keys"),
+	)
+
+	diagnosisKeysTotalMetric = cb.NewInt64ValueObserver("covidshield.app.diagnosis_keys.total",
+		metric.WithDescription("Total number of diagnosis keys"),
 	)
 }
 


### PR DESCRIPTION
The purpose of the feature is to add additional metrics to the current metrics output that show how many claimed one time codes are in the database (claimed keys) and how many diagnostic keys have been uploaded. Based on this data, we should be able to create alerts on unusual behaviour. Here is an example output:

```
{
   "time":"2020-06-21T00:23:07.4527958Z",
   "updates":[
      {
         "name":"covidshield.system.memory.total",
         "min":4131897344,
         "max":4131897344,
         "sum":4131897344,
         "count":1
      },
      ...
      {
         "name":"covidshield.app.claimed_keys.total",
         "min":4,
         "max":4,
         "sum":4,
         "count":1
      },
      {
         "name":"covidshield.app.diagnosis_keys.total",
         "min":56,
         "max":56,
         "sum":56,
         "count":1
      }
   ]
}
```