### PR TITLE
Pin TF version

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,11 +4,12 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Run Snyk to check for vulnerabilities
-      uses: snyk/actions/golang@master
-      env:
-        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      with:
-        command: monitor
-        args: --file=go.mod --org=exposurenotification --project-name=covid-shield-server
+      - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b # pin@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/golang@d9ca26550c26e3cbbbdde59ee4ace0a2f385897c # pin@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: monitor
+          args: --file=go.mod --org=exposurenotification
+            --project-name=covid-shield-server

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.13.0-beta2
 
       - name: Terraform Init
         run: |
@@ -67,6 +69,8 @@ jobs:
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.13.0-beta2
 
       - name: Terraform Init
         run: |


### PR DESCRIPTION
When we first provisioned the server environment, the Terraform GitHub action still pulled the latest available version of Terraform, in this case, 0.13. 

A recent update to the GitHub action, this was changed to the latest stable version: 
https://github.com/hashicorp/setup-terraform/issues/23#issuecomment-646621002

However, our current state was set with 0.13 which means the current action fails:
https://github.com/cds-snc/covid-shield-server/runs/788565440

This update to our action flow pins the Terraform version to 0.13.