### PR TITLE
Adding ECR Prod as a registry target

### DIFF
--- a/.github/workflows/ecr-prod.yml
+++ b/.github/workflows/ecr-prod.yml
@@ -1,0 +1,63 @@
+name: ECR Production Container Builds
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build-n-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build Key Retrieval
+        env:
+          ECR_REGISTRY: ${{ secrets.PROD_ECR_REGISTRY }}
+          ECR_REPOSITORY: covid-server/key-retrieval
+          GITHUB_SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref }}
+          COMPONENT: key-retrieval
+        run: |
+          docker build --build-arg branch=$BRANCH --build-arg revision=$GITHUB_SHA --build-arg component=$COMPONENT -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: Build Key Submission
+        env:
+          ECR_REGISTRY: ${{ secrets.PROD_ECR_REGISTRY }}
+          ECR_REPOSITORY: covid-server/key-submission
+          GITHUB_SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref }}
+          COMPONENT: key-submission
+        run: |
+          docker build --build-arg branch=$BRANCH --build-arg revision=$GITHUB_SHA --build-arg component=$COMPONENT -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: Build Monolith
+        env:
+          ECR_REGISTRY: ${{ secrets.PROD_ECR_REGISTRY }}
+          ECR_REPOSITORY: covid-server/monolith
+          GITHUB_SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref }}
+          COMPONENT: monolith
+        run: |
+          docker build --build-arg branch=$BRANCH --build-arg revision=$GITHUB_SHA --build-arg component=$COMPONENT -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: Logout of Amazon ECR
+        if: always()
+        run: docker logout ${{ secrets.PROD_ECR_REGISTRY }}


### PR DESCRIPTION
This pull request adds a GitHub action that will push the current image into the docker registry used for the production deploys.