### PR TITLE
Adds example bootstrap configuration for Terraform

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -34,3 +34,4 @@ git pull upstream master
 - Added basic cloudwatch alerts - more alerts to come later (https://github.com/cds-snc/covid-shield-server/pull/45)
 - Added log metrics for key counts in the database (https://github.com/cds-snc/covid-shield-server/pull/51)
 - Added `hashID` logic based on a provincial healthcare provider feature request (https://github.com/cds-snc/covid-shield-server/pull/50)
+- Added example bootstrap configuration for terraform (https://github.com/cds-snc/covid-shield-server/pull/83)

--- a/config/terraform/aws/bootstrap/provider.tf
+++ b/config/terraform/aws/bootstrap/provider.tf
@@ -1,0 +1,40 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = "ca-central-1"
+}
+
+resource "aws_s3_bucket" "storage_bucket" {
+  bucket = var.storage_bucket
+  acl    = "private"
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_dynamodb_table" "terraform_state_lock" {
+  name           = "terraform-lock"
+  read_capacity  = 5
+  write_capacity = 5
+  hash_key       = "LockID"
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    ("CostCentre") = "CovidShield"
+  }
+}
+
+
+resource "aws_route53_zone" "covidshield" {
+  name = var.route53_zone_name
+
+  tags = {
+    ("CostCentre") = "CovidShield"
+  }
+}

--- a/config/terraform/aws/bootstrap/variables.tf
+++ b/config/terraform/aws/bootstrap/variables.tf
@@ -1,0 +1,10 @@
+###
+# Global
+###
+variable "route53_zone_name" {
+  type = string
+}
+
+variable "storage_bucket" {
+  type = string
+}


### PR DESCRIPTION
Closes #59, closes #81, closes #73, and closes #82 which are all concerned with how the initial infrastructure is provisioned to manage the terraform state. 

The bootstrap terraform included in this PR should be run before the main terraform is run. It will:

- Create a new and securely encrypted S3 bucket 
- Provision a DynamoDB table to handle state locks
- Provision the Route53 zone that the main application will live in.

It is important to note that once this terraform is run, the Route 53 zone has to be manually imported into the terraform state for the main application. 

ex: `terraform import aws_route53_zone.covidshield XXXXYYYYZZZZ` 

More information can be found here: https://www.terraform.io/docs/providers/aws/r/route53_zone.html#import