### PR TITLE
Removed portal security group

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -35,3 +35,4 @@ git pull upstream master
 - Added log metrics for key counts in the database (https://github.com/cds-snc/covid-shield-server/pull/51)
 - Added `hashID` logic based on a provincial healthcare provider feature request (https://github.com/cds-snc/covid-shield-server/pull/50)
 - Changing the code expiry window from 10 minutes to 24 hours (https://github.com/cds-snc/covid-shield-server/pull/56)
+- Removed portal security group egress (https://github.com/cds-snc/covid-shield-server/pull/84)

--- a/config/terraform/aws/networking.tf
+++ b/config/terraform/aws/networking.tf
@@ -194,13 +194,6 @@ resource "aws_security_group" "covidshield_load_balancer" {
     cidr_blocks = [var.vpc_cidr_block]
   }
 
-  egress {
-    protocol    = "tcp"
-    from_port   = 3000
-    to_port     = 3000
-    cidr_blocks = [var.vpc_cidr_block]
-  }
-
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
   }


### PR DESCRIPTION
Closes #70. The inherited Terraform included an egress to connect to the healthcare portal component. This component is currently out of scope so the egress port can be removed.