### PR TITLE
Add VPC flow logging

### DIFF
--- a/config/terraform/aws/vpc_flow_log.tf
+++ b/config/terraform/aws/vpc_flow_log.tf
@@ -6,7 +6,8 @@ resource "aws_flow_log" "vpc_flow_logs" {
 }
 
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
-  name = "vpc_flow_logs"
+  name              = "vpc_flow_logs"
+  retention_in_days = 30
 }
 
 resource "aws_iam_role" "vpc_flow_logs" {

--- a/config/terraform/aws/vpc_flow_log.tf
+++ b/config/terraform/aws/vpc_flow_log.tf
@@ -1,4 +1,4 @@
-resource "aws_flow_log" "example" {
+resource "aws_flow_log" "covidshield" {
   log_destination      = aws_s3_bucket.vpc_flow_log.arn
   log_destination_type = "s3"
   traffic_type         = "ALL"

--- a/config/terraform/aws/vpc_flow_log.tf
+++ b/config/terraform/aws/vpc_flow_log.tf
@@ -7,6 +7,7 @@ resource "aws_flow_log" "vpc_flow_logs" {
 
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
   name              = "vpc_flow_logs"
+  kms_key_id        = aws_kms_key.cw.key_id
   retention_in_days = 30
 }
 

--- a/config/terraform/aws/vpc_flow_log.tf
+++ b/config/terraform/aws/vpc_flow_log.tf
@@ -1,4 +1,4 @@
-esource "aws_flow_log" "example" {
+resource "aws_flow_log" "example" {
   log_destination      = aws_s3_bucket.vpc_flow_log.arn
   log_destination_type = "s3"
   traffic_type         = "ALL"

--- a/config/terraform/aws/vpc_flow_log.tf
+++ b/config/terraform/aws/vpc_flow_log.tf
@@ -1,18 +1,54 @@
-resource "aws_flow_log" "covidshield" {
-  log_destination      = aws_s3_bucket.vpc_flow_log.arn
-  log_destination_type = "s3"
-  traffic_type         = "ALL"
-  vpc_id               = aws_vpc.covidshield.id
+resource "aws_flow_log" "vpc_flow_logs" {
+  iam_role_arn    = aws_iam_role.vpc_flow_logs.arn
+  log_destination = aws_cloudwatch_log_group.vpc_flow_logs.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.covidshield.id
 }
 
-resource "aws_s3_bucket" "vpc_flow_log" {
-  bucket = "${var.vpc_name}_flow_log_${random_string.random.result}"
-  acl    = "private"
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
+  name = "vpc_flow_logs"
+}
+
+resource "aws_iam_role" "vpc_flow_logs" {
+  name = "vpc_flow_logs"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "vpc-flow-logs.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
     }
-  }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "vpc_flow_logs" {
+  name = "vpc_flow_logs"
+  role = aws_iam_role.vpc_flow_logs.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
 }

--- a/config/terraform/aws/vpc_flow_log.tf
+++ b/config/terraform/aws/vpc_flow_log.tf
@@ -1,0 +1,18 @@
+esource "aws_flow_log" "example" {
+  log_destination      = aws_s3_bucket.vpc_flow_log.arn
+  log_destination_type = "s3"
+  traffic_type         = "ALL"
+  vpc_id               = aws_vpc.covidshield.id
+}
+
+resource "aws_s3_bucket" "vpc_flow_log" {
+  bucket = "${var.vpc_name}_flow_log_${random_string.random.result}"
+  acl    = "private"
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #63. This pull request enables flow logging on the main CovidShield VPC and put the logs into an encrypted Cloudwatch log