### PR TITLE
Small changes to Cloudfront settings

### DIFF
--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -21,7 +21,7 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
   aliases = ["retrieval.${var.route53_zone_name}"]
 
   default_cache_behavior {
-    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = aws_lb.covidshield_key_retrieval.name
 
@@ -38,6 +38,7 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 7200
+    compress               = true
   }
 
   restrictions {


### PR DESCRIPTION
Closes #68 and closes #69 

Restricts the methods that can access the Cloudfront distribution to GET and HEAD, which are the two methods that are compressed. Should the retrieval server ever need other methods opened up, we can adjust it later. 

Also enabled compression for Cloudfront.