### PR TITLE
Enable SSL connection if DB is RDS

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,6 +31,9 @@ RUN apt-get update \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
+RUN mkdir /etc/aws-certs
+RUN wget -P /etc/aws-certs https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem
+
 ENV DEBIAN_FRONTEND=dialog
 
 RUN echo "export PATH=${GOROOT}/bin:${PATH}" >> /root/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="${GOLDFLAGS}" -o server ./cmd/${component}
 
+RUN mkdir /etc/aws-certs
+RUN wget -P /etc/aws-certs https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem
+
 ###
 # Step 2 - Build
 ###
@@ -39,6 +42,7 @@ WORKDIR /usr/local/bin
 # Import the user and group files from step 1
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/aws-certs /etc/aws-certs
 COPY --from=builder --chown=${USER}:${USER} /go/src/github.com/CovidShield/server/server /usr/local/bin/server
 
 USER ${USER}:${USER}

--- a/pkg/persistence/db.go
+++ b/pkg/persistence/db.go
@@ -2,18 +2,21 @@ package persistence
 
 import (
 	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"math/big"
+	"regexp"
 	"strings"
 	"time"
 
 	pb "github.com/CovidShield/server/pkg/proto/covidshield"
 
 	"github.com/Shopify/goose/logger"
-	// inject mysql support for database/sql
-	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-sql-driver/mysql"
 	"golang.org/x/crypto/nacl/box"
 )
 
@@ -72,9 +75,36 @@ func Dial(url string) (Conn, error) {
 	} else {
 		url += "?parseTime=true"
 	}
+
+	// Check if we are connecting to RDS
+	if strings.Contains(url, "rds.amazonaws.com") {
+
+		rootCertPool := x509.NewCertPool()
+		pem, err := ioutil.ReadFile("/etc/aws-certs/rds-ca-2019-root.pem")
+		
+    if err != nil {
+			log(nil, err).Fatal("AWS RDS Cert bundle not found")
+		}
+		
+    if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
+			log(nil, err).Fatal("Could not append certs")
+		}
+
+		re := regexp.MustCompile(`tcp\((.*)\)`)
+		match := re.FindStringSubmatch(url)
+
+		if len(match) > 0 {
+			mysql.RegisterTLSConfig("custom", &tls.Config{
+				ServerName: match[1],
+				RootCAs: rootCertPool,
+			})
+			url += "&tls=custom"
+		}
+	}
+
 	db, err := sql.Open("mysql", url)
 	if err != nil {
-		return nil, err
+		log(nil, err).Fatal("Could not connect to database")
 	}
 	db.SetConnMaxLifetime(maxConnLifetime)
 	db.SetMaxOpenConns(maxOpenConns)


### PR DESCRIPTION
Closes #64. 

Docker image are now built with the AWS cert bundle. If the DB is configured to use an `*.rds.amazonaws.com` domain, then it will configure the MySQL connection string to use the TLS connection.