### PR TITLE
Set key ARN

### DIFF
--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_group" "covidshield" {
   name       = var.cloudwatch_log_group_name
-  kms_key_id = aws_kms_key.cw.key_id
+  kms_key_id = aws_kms_key.cw.arn
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value

--- a/config/terraform/aws/vpc_flow_log.tf
+++ b/config/terraform/aws/vpc_flow_log.tf
@@ -7,7 +7,7 @@ resource "aws_flow_log" "vpc_flow_logs" {
 
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
   name              = "vpc_flow_logs"
-  kms_key_id        = aws_kms_key.cw.key_id
+  kms_key_id        = aws_kms_key.cw.arn
   retention_in_days = 30
 }
 


### PR DESCRIPTION
Uses the KMS key ARN vs ID, although the value in CloudWatch TF object is ID.