### PR TITLE
Set Fargate platform to 1.4.0

### DIFF
--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -70,10 +70,11 @@ resource "aws_ecs_service" "covidshield_key_retrieval" {
     aws_lb_listener.covidshield_key_retrieval,
   ]
 
-  name            = var.ecs_key_retrieval_name
-  cluster         = aws_ecs_cluster.covidshield.id
-  task_definition = aws_ecs_task_definition.covidshield_key_retrieval.arn
-  launch_type     = "FARGATE"
+  name             = var.ecs_key_retrieval_name
+  cluster          = aws_ecs_cluster.covidshield.id
+  task_definition  = aws_ecs_task_definition.covidshield_key_retrieval.arn
+  launch_type      = "FARGATE"
+  platform_version = "1.4"
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 
@@ -193,10 +194,11 @@ resource "aws_ecs_service" "covidshield_key_submission" {
     aws_lb_listener.covidshield_key_submission,
   ]
 
-  name            = var.ecs_key_submission_name
-  cluster         = aws_ecs_cluster.covidshield.id
-  task_definition = aws_ecs_task_definition.covidshield_key_submission.arn
-  launch_type     = "FARGATE"
+  name             = var.ecs_key_submission_name
+  cluster          = aws_ecs_cluster.covidshield.id
+  task_definition  = aws_ecs_task_definition.covidshield_key_submission.arn
+  launch_type      = "FARGATE"
+  platform_version = "1.4"
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 

--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -74,7 +74,7 @@ resource "aws_ecs_service" "covidshield_key_retrieval" {
   cluster          = aws_ecs_cluster.covidshield.id
   task_definition  = aws_ecs_task_definition.covidshield_key_retrieval.arn
   launch_type      = "FARGATE"
-  platform_version = "1.4"
+  platform_version = "1.4.0"
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 
@@ -198,7 +198,7 @@ resource "aws_ecs_service" "covidshield_key_submission" {
   cluster          = aws_ecs_cluster.covidshield.id
   task_definition  = aws_ecs_task_definition.covidshield_key_submission.arn
   launch_type      = "FARGATE"
-  platform_version = "1.4"
+  platform_version = "1.4.0"
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 


### PR DESCRIPTION
Closes #90. Unfortunately the `LATEST` version of Fargate defaults to 1.3. We would like to use 1.4 features.