### PR TITLE
Switch DB from r4 to r5

### DIFF
--- a/config/terraform/aws/variables.auto.tfvars
+++ b/config/terraform/aws/variables.auto.tfvars
@@ -62,7 +62,7 @@ rds_server_db_user = "root"
 # Value should come from a TF_VAR environment variable (e.g. set in a Github Secret)
 # rds_server_db_password       = ""
 rds_server_allocated_storage = "5"
-rds_server_instance_class    = "db.r4.large"
+rds_server_instance_class    = "db.r5.large"
 
 ###
 # AWS Route 53 - route53.tf


### PR DESCRIPTION
The r5 series is the next generation version of the r4 database line.