### PR TITLE
BVC-41 :: Fixes faulty bounds checking for keysRemaining in key upload

### DIFF
--- a/pkg/persistence/db.go
+++ b/pkg/persistence/db.go
@@ -32,7 +32,6 @@ type Conn interface {
 	// less than 14 days ago.
 	FetchKeysForDateNumber(string, uint32, int32) ([]*pb.TemporaryExposureKey, error)
 	StoreKeys(*[32]byte, []*pb.TemporaryExposureKey) error
-	CheckRemainingKeys(*[32]byte) (int, error)
 	NewKeyClaim(string, string, string) (string, error)
 	CheckHashID(string) (int64, error)
 	ClaimKey(string, []byte) ([]byte, error)
@@ -165,10 +164,6 @@ func (c *conn) PrivForPub(pub []byte) ([]byte, error) {
 
 func (c *conn) StoreKeys(appPubKey *[32]byte, keys []*pb.TemporaryExposureKey) error {
 	return registerDiagnosisKeys(c.db, appPubKey, keys)
-}
-
-func (c *conn) CheckRemainingKeys(appPubKey *[32]byte) (int, error){
-	return checkRemainingKeys(c.db, appPubKey)
 }
 
 func (c *conn) FetchKeysForDateNumber(region string, dateNumber uint32, currentRSIN int32) ([]*pb.TemporaryExposureKey, error) {

--- a/pkg/persistence/db.go
+++ b/pkg/persistence/db.go
@@ -32,6 +32,7 @@ type Conn interface {
 	// less than 14 days ago.
 	FetchKeysForDateNumber(string, uint32, int32) ([]*pb.TemporaryExposureKey, error)
 	StoreKeys(*[32]byte, []*pb.TemporaryExposureKey) error
+	CheckRemainingKeys(*[32]byte) (int, error)
 	NewKeyClaim(string, string, string) (string, error)
 	CheckHashID(string) (int64, error)
 	ClaimKey(string, []byte) ([]byte, error)
@@ -164,6 +165,10 @@ func (c *conn) PrivForPub(pub []byte) ([]byte, error) {
 
 func (c *conn) StoreKeys(appPubKey *[32]byte, keys []*pb.TemporaryExposureKey) error {
 	return registerDiagnosisKeys(c.db, appPubKey, keys)
+}
+
+func (c *conn) CheckRemainingKeys(appPubKey *[32]byte) (int, error){
+	return checkRemainingKeys(c.db, appPubKey)
 }
 
 func (c *conn) FetchKeysForDateNumber(region string, dateNumber uint32, currentRSIN int32) ([]*pb.TemporaryExposureKey, error) {

--- a/pkg/persistence/queries.go
+++ b/pkg/persistence/queries.go
@@ -327,19 +327,6 @@ type queryRower interface {
 	QueryRow(query string, args ...interface{}) *sql.Row
 }
 
-func checkRemainingKeys(db *sql.DB, appPubKey *[32]byte) (int, error) {
-	var remainingKeys int
-
-	row := db.QueryRow("SELECT remaining_keys FROM encryption_keys WHERE app_public_key = ?", appPubKey[:])
-	err := row.Scan(&remainingKeys)
-
-	if err != nil {
-		return 0, err
-	}
-
-	return remainingKeys, err
-}
-
 func checkClaimKeyBan(db queryRower, identifier string) (triesRemaining int, banDuration time.Duration, err error) {
 	var failures uint16
 	var lastFailure time.Time

--- a/pkg/persistence/queries.go
+++ b/pkg/persistence/queries.go
@@ -310,6 +310,7 @@ func registerDiagnosisKeys(db *sql.DB, appPubKey *[32]byte, keys []*pb.Temporary
 	if err = tx.Commit(); err != nil {
 		return err
 	}
+	log(nil, nil).WithField("keys", keysInserted).Info("Inserted keys")
 	return nil
 }
 

--- a/pkg/persistence/queries.go
+++ b/pkg/persistence/queries.go
@@ -327,6 +327,19 @@ type queryRower interface {
 	QueryRow(query string, args ...interface{}) *sql.Row
 }
 
+func checkRemainingKeys(db *sql.DB, appPubKey *[32]byte) (int, error) {
+	var remainingKeys int
+
+	row := db.QueryRow("SELECT remaining_keys FROM encryption_keys WHERE app_public_key = ?", appPubKey[:])
+	err := row.Scan(&remainingKeys)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return remainingKeys, err
+}
+
 func checkClaimKeyBan(db queryRower, identifier string) (triesRemaining int, banDuration time.Duration, err error) {
 	var failures uint16
 	var lastFailure time.Time

--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -138,6 +138,14 @@ func (s *uploadServlet) upload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if remainingKeys, _ := s.db.CheckRemainingKeys(appPubKey); remainingKeys < len(upload.GetKeys()){
+		requestError(
+			ctx, w, err, "too many keys provided",
+			http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_TOO_MANY_KEYS),
+		)
+		return
+	}
+
 	ts := time.Unix(upload.GetTimestamp().Seconds, 0)
 	if math.Abs(time.Since(ts).Seconds()) > 3600 {
 		requestError(

--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -158,6 +158,12 @@ func (s *uploadServlet) upload(w http.ResponseWriter, r *http.Request) {
 			http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_INVALID_KEYPAIR),
 		)
 		return
+	} else if err == persistence.ErrTooManyKeys {
+		requestError(
+			ctx, w, err, "not enough keys remaining",
+			http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_TOO_MANY_KEYS),
+		)
+		return
 	} else if err != nil {
 		requestError(
 			ctx, w, err, "failed to store diagnosis keys",

--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -138,7 +138,7 @@ func (s *uploadServlet) upload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if remainingKeys, _ := s.db.CheckRemainingKeys(appPubKey); remainingKeys < len(upload.GetKeys()){
+	if remainingKeys, _ := s.db.CheckRemainingKeys(appPubKey); remainingKeys <= len(upload.GetKeys()){
 		requestError(
 			ctx, w, err, "too many keys provided",
 			http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_TOO_MANY_KEYS),

--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -138,7 +138,7 @@ func (s *uploadServlet) upload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if remainingKeys, _ := s.db.CheckRemainingKeys(appPubKey); remainingKeys <= len(upload.GetKeys()){
+	if remainingKeys, _ := s.db.CheckRemainingKeys(appPubKey); remainingKeys < len(upload.GetKeys()){
 		requestError(
 			ctx, w, err, "too many keys provided",
 			http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_TOO_MANY_KEYS),

--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -138,14 +138,6 @@ func (s *uploadServlet) upload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if remainingKeys, _ := s.db.CheckRemainingKeys(appPubKey); remainingKeys < len(upload.GetKeys()){
-		requestError(
-			ctx, w, err, "too many keys provided",
-			http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_TOO_MANY_KEYS),
-		)
-		return
-	}
-
 	ts := time.Unix(upload.GetTimestamp().Seconds, 0)
 	if math.Abs(time.Since(ts).Seconds()) > 3600 {
 		requestError(

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -82,7 +82,7 @@ module Helper
     end
 
     def diagnosis_originators
-      @dbconn.query("SELECT originator FROM encryption_keys").map(&:values).map(&:first)
+      @dbconn.query("SELECT originator FROM diagnosis_keys").map(&:values).map(&:first)
     end
 
     def random_hash

--- a/test/upload_test.rb
+++ b/test/upload_test.rb
@@ -193,6 +193,51 @@ class UploadTest < MiniTest::Test
     assert_result(resp, 400, :INVALID_KEYPAIR)
   end
 
+  def test_variable_limits
+    keys = (1..50).map { |n| key_n(n) }
+    keyset = new_valid_keyset
+
+    # Upload first 14
+    payload = Covidshield::Upload.new(
+      timestamp: Time.now, keys: keys[0..13]
+    ).to_proto
+    req = encrypted_request(payload, keyset)
+    resp = @sub_conn.post('/upload', req.to_proto)
+    assert_result(resp, 200, :NONE)
+
+    # Upload additional 13
+    payload = Covidshield::Upload.new(
+      timestamp: Time.now, keys: keys[14..26]
+    ).to_proto
+    req = encrypted_request(payload, keyset)
+    resp = @sub_conn.post('/upload', req.to_proto)
+    assert_result(resp, 200, :NONE)
+
+    # Upload additional 2 (expect failure)
+    payload = Covidshield::Upload.new(
+      timestamp: Time.now, keys: keys[27..29]
+    ).to_proto
+    req = encrypted_request(payload, keyset)
+    resp = @sub_conn.post('/upload', req.to_proto)
+    assert_result(resp, 400, :TOO_MANY_KEYS)
+
+    # Upload additional 1 (expect success)
+    payload = Covidshield::Upload.new(
+      timestamp: Time.now, keys: [keys[27]]
+    ).to_proto
+    req = encrypted_request(payload, keyset)
+    resp = @sub_conn.post('/upload', req.to_proto)
+    assert_result(resp, 200, :NONE)
+
+    # Upload additional 1 (expect failure)
+    payload = Covidshield::Upload.new(
+      timestamp: Time.now, keys: [keys[28]]
+    ).to_proto
+    req = encrypted_request(payload, keyset)
+    resp = @sub_conn.post('/upload', req.to_proto)
+    assert_result(resp, 400, :INVALID_KEYPAIR)
+  end
+
   private
 
   def key_n(n)


### PR DESCRIPTION
Fixes #111

Extracts `remaining_keys` on initial query. If `keys_inserted` is larger than `remaining_keys` rolls back transaction.