### PR TITLE
BVC-48 :: Enfore minimum length on KEY_CLAIM_TOKEN

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       DB_PORT: 3306
       DATABASE_URL: "test:password@tcp(db)/test"
       ECDSA_KEY: 30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a
-      KEY_CLAIM_TOKEN: thisisatoken=302
+      KEY_CLAIM_TOKEN: thisisaverylongtoken=302
       RETRIEVE_HMAC_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       METRIC_PROVIDER: stdout
     

--- a/.github/workflows/pr-test-ci.yml
+++ b/.github/workflows/pr-test-ci.yml
@@ -32,5 +32,5 @@ jobs:
         DB_NAME: test
         DB_PORT: 3306
         ECDSA_KEY: 30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a
-        KEY_CLAIM_TOKEN: thisisatoken=302
+        KEY_CLAIM_TOKEN: thisisaverylongtoken=302
         RETRIEVE_HMAC_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/dev.yml
+++ b/dev.yml
@@ -22,7 +22,7 @@ up:
   - railgun
 
 env:
-  KEY_CLAIM_TOKEN: thisisatoken=302
+  KEY_CLAIM_TOKEN: thisisaverylongtoken=302
   RETRIEVE_HMAC_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   ECDSA_KEY: 30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a
   DATABASE_URL: "root@tcp(covidshield.railgun)/covidshield"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,6 @@ services:
     restart: always
     environment:
       DATABASE_URL: covidshield:covidshield@tcp(mysql)/covidshield
-      KEY_CLAIM_TOKEN: thisisatoken=302
+      KEY_CLAIM_TOKEN: thisisaverylongtoken=302
       METRIC_PROVIDER: ""
       TRACER_PROVIDER: ""

--- a/pkg/keyclaim/authenticator.go
+++ b/pkg/keyclaim/authenticator.go
@@ -32,6 +32,9 @@ func NewAuthenticator() Authenticator {
 		if len(parts[0]) > 63 {
 			panic("token too long")
 		}
+		if len(parts[0]) < 20 {
+			panic("token too short")
+		}
 		if len(parts[1]) > 31 {
 			panic("region too long")
 		}

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -92,7 +92,7 @@ module Helper
     def new_valid_one_time_code
       resp = @sub_conn.post do |req|
         req.url('/new-key-claim')
-        req.headers['Authorization'] = 'Bearer first-token'
+        req.headers['Authorization'] = 'Bearer first-very-long-token'
       end
       assert_response(resp, 200, 'text/plain; charset=utf-8')
       resp.body.chomp
@@ -207,7 +207,7 @@ module Helper
       pid = Process.spawn(
         {
           'BIND_ADDR' => addr,
-          'KEY_CLAIM_TOKEN' => 'first-token=302:second-token=302',
+          'KEY_CLAIM_TOKEN' => 'first-very-long-token=302:second-very-long-token=302',
           'DATABASE_URL' => DATABASE_URL,
         },
         bin, STDERR => File.open('/dev/null')

--- a/test/new_key_claim_hash_id_test.rb
+++ b/test/new_key_claim_hash_id_test.rb
@@ -9,7 +9,7 @@ class NewKeyClaimhashIDTest < MiniTest::Test
     
     resp = @sub_conn.post do |req|
       req.url('/new-key-claim/abcd')
-      req.headers['Authorization'] = 'Bearer second-token'
+      req.headers['Authorization'] = 'Bearer second-very-long-token'
     end
     assert_response(resp, 404, 'text/plain; charset=utf-8', body: "404 page not found\n")
 
@@ -22,7 +22,7 @@ class NewKeyClaimhashIDTest < MiniTest::Test
 
     resp = @sub_conn.post do |req|
       req.url("/new-key-claim/#{hash_id}")
-      req.headers['Authorization'] = 'Bearer second-token'
+      req.headers['Authorization'] = 'Bearer second-very-long-token'
     end
     assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
     previous_code = resp.body
@@ -30,7 +30,7 @@ class NewKeyClaimhashIDTest < MiniTest::Test
     # Returns another code if hashID not claimed
     resp = @sub_conn.post do |req|
       req.url("/new-key-claim/#{hash_id}")
-      req.headers['Authorization'] = 'Bearer second-token'
+      req.headers['Authorization'] = 'Bearer second-very-long-token'
     end
     assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
     refute_equal(previous_code, resp.body)
@@ -50,7 +50,7 @@ class NewKeyClaimhashIDTest < MiniTest::Test
 
     resp = @sub_conn.post do |req|
       req.url("/new-key-claim/#{hash_id}")
-      req.headers['Authorization'] = 'Bearer second-token'
+      req.headers['Authorization'] = 'Bearer second-very-long-token'
     end
     assert_response(resp, 401, 'text/plain; charset=utf-8', body: "unauthorized\n")
 

--- a/test/new_key_claim_test.rb
+++ b/test/new_key_claim_test.rb
@@ -17,17 +17,17 @@ class NewKeyClaimTest < MiniTest::Test
 
     resp = @sub_conn.post do |req|
       req.url('/new-key-claim')
-      req.headers['Authorization'] = 'Bearer first-token'
+      req.headers['Authorization'] = 'Bearer first-very-long-token'
     end
     assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
-    assert_equal(['first-token'], encryption_originators)
+    assert_equal(['first-very-long-token'], encryption_originators)
 
     resp = @sub_conn.post do |req|
       req.url('/new-key-claim')
-      req.headers['Authorization'] = 'Bearer second-token'
+      req.headers['Authorization'] = 'Bearer second-very-long-token'
     end
     assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
-    assert_equal(['first-token', 'second-token'], encryption_originators)
+    assert_equal(['first-very-long-token', 'second-very-long-token'], encryption_originators)
 
     %w[get patch delete put].each do |meth|
       resp = @sub_conn.send(meth, '/new-key-claim')

--- a/test/upload_test.rb
+++ b/test/upload_test.rb
@@ -19,7 +19,7 @@ class UploadTest < MiniTest::Test
     req = encrypted_request(dummy_payload, new_valid_keyset)
     resp = @sub_conn.post('/upload', req.to_proto)
     assert_result(resp, 200, :NONE)
-    assert_equal(['first-token'], diagnosis_originators)
+    assert_equal(['first-very-long-token'], diagnosis_originators)
 
     # timestamp almost too old
     req = encrypted_request(dummy_payload(timestamp: Time.at(Time.now.to_i - 59*60)), new_valid_keyset)


### PR DESCRIPTION
Closes #113. 

Enforced a minimum length of 20 character for each `KEY_CLAIM_TOKEN`