### PR TITLE
BVC 52 :: Extract last appended IP from X-Forwarded-For header

### DIFF
--- a/pkg/server/keyclaim.go
+++ b/pkg/server/keyclaim.go
@@ -199,7 +199,8 @@ var numeric = regexp.MustCompile("^[0-9]+$")
 func getIP(r *http.Request) string {
 	forwarded := r.Header.Get("X-FORWARDED-FOR")
 	if forwarded != "" {
-		return forwarded
+		IPList := strings.Split(forwarded, ",")
+		return IPList[len(IPList)-1]
 	}
 	// If the RemoteAddr is of the form $ip:$port, return only the IP
 	parts := strings.Split(r.RemoteAddr, ":")


### PR DESCRIPTION
Closes #116 

Assuming:

The default forwarded request from ALB to backend X-Forwarded-For HTTP header is as below:

`X-Forwarded-For: $sourceIP`

Therefore, any application/service processing HTTP request X-Forwarded-For HTTP header will pick $sourceIP in the case above.

In the case where a client sends a custom http request with a fake IP 1.1.1.1 included in the X-Forwarded-For HTTP header the ALB forwards the request to the back end as below:

` X-Forwarded-For: 1.1.1.1,$sourceIP`

Therefore, any application/service processing HTTP request X-Forwarded-For HTTP header should always pick the last appended IP which is the $sourceIP in the case above.

The code only needs to select the last IP from a comma separated list.
