### PR TITLE
Trims last IP passed from ALB

### DIFF
--- a/pkg/server/keyclaim.go
+++ b/pkg/server/keyclaim.go
@@ -200,7 +200,7 @@ func getIP(r *http.Request) string {
 	forwarded := r.Header.Get("X-FORWARDED-FOR")
 	if forwarded != "" {
 		IPList := strings.Split(forwarded, ",")
-		return IPList[len(IPList)-1]
+		return strings.TrimSpace(IPList[len(IPList)-1])
 	}
 	// If the RemoteAddr is of the form $ip:$port, return only the IP
 	parts := strings.Split(r.RemoteAddr, ":")


### PR DESCRIPTION
Part of #117.  Fixes a bug in the IP reader from the ALB. We assumed it would send IPs in this format `x,y,z` when in fact it sends them in `x, y, z`. 