### PR TITLE
Update EN framework configuration

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	response = `{"minimumRiskScore":9,"attenuationLevelValues":[0,0,2,2,2,2,2,2],"attenuationWeight":50,"daysSinceLastExposureLevelValues":[0,1,1,1,1,1,1,1],"daysSinceLastExposureWeight":50,"durationLevelValues":[0,0,0,0,5,5,5,5],"durationWeight":50,"transmissionRiskLevelValues":[1,1,1,1,1,1,1,1],"transmissionRiskWeight":50}`
+	response = `{"minimumRiskScore":1,"attenuationLevelValues":[0,0,2,2,2,2,2,2],"attenuationWeight":50,"daysSinceLastExposureLevelValues":[0,1,1,1,1,1,1,1],"daysSinceLastExposureWeight":50,"durationLevelValues":[0,0,0,0,5,5,5,5],"durationWeight":50,"transmissionRiskLevelValues":[1,1,1,1,1,1,1,1],"transmissionRiskWeight":50}`
 )
 
 func NewConfigServlet() srvutil.Servlet {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	response = `{"minimumRiskScore":1,"attenuationLevelValues":[0,5,5,5,5,5,5,5],"attenuationWeight":50,"daysSinceLastExposureLevelValues":[1,1,1,1,1,1,1,1],"daysSinceLastExposureWeight":50,"durationLevelValues":[0,0,0,0,5,5,5,5],"durationWeight":50,"transmissionRiskLevelValues":[1,1,1,1,1,1,1,1],"transmissionRiskWeight":50}`
+	response = `{"minimumRiskScore":9,"attenuationLevelValues":[0,0,2,2,2,2,2,2],"attenuationWeight":50,"daysSinceLastExposureLevelValues":[0,1,1,1,1,1,1,1],"daysSinceLastExposureWeight":50,"durationLevelValues":[0,0,0,0,5,5,5,5],"durationWeight":50,"transmissionRiskLevelValues":[1,1,1,1,1,1,1,1],"transmissionRiskWeight":50}`
 )
 
 func NewConfigServlet() srvutil.Servlet {


### PR DESCRIPTION
For now we should set the simplest configuration possible that conforms to HC guidance (<=2m, >=15 minutes). We assume longer exposures are not higher risk for now.

The weights are unused and reserved for future use.

@jeberhardt feel free to comment with some more details about how we arrived at this configuration.