### PR TITLE
waf needs to block by default otherwise it won't count hits

### DIFF
--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -6,7 +6,7 @@ resource "aws_wafv2_web_acl" "key_submission" {
   scope = "REGIONAL"
 
   default_action {
-    allow {}
+    block {}
   }
 
   rule {


### PR DESCRIPTION
With default action of allow, none of the count rules get any hits. 

Fixes https://github.com/cds-snc/covid-shield-server/pull/126