### PR TITLE
Adds Heroku PR Review apps

### DIFF
--- a/Dockerfile.heroku
+++ b/Dockerfile.heroku
@@ -1,0 +1,52 @@
+###
+# Step 1 - Compile
+###
+FROM golang:1.14-alpine AS builder
+
+ARG component=${component:-key-retrieval}
+ARG branch
+ARG revision
+
+ENV GO111MODULE=on
+ENV USER=covidshield
+ENV UID=10001
+ENV GOLDFLAGS="-X github.com/CovidShield/server/pkg/server.branch=${branch} -X github.com/CovidShield/server/pkg/server.revision=${revision}"
+
+WORKDIR /go/src/github.com/CovidShield/server
+
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    "${USER}"
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="${GOLDFLAGS}" -o server ./cmd/monolith
+
+RUN mkdir /etc/aws-certs
+RUN wget -P /etc/aws-certs https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem
+
+###
+# Step 2 - Build
+###
+FROM alpine
+
+RUN apk add --no-cache bash
+
+ARG PORT
+
+WORKDIR /usr/local/bin
+
+# Import the user and group files from step 1
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/aws-certs /etc/aws-certs
+COPY --from=builder /go/src/github.com/CovidShield/server/config.yaml /usr/local/bin/config.yaml
+COPY --from=builder /go/src/github.com/CovidShield/server/server /usr/local/bin/server
+COPY --from=builder /go/src/github.com/CovidShield/server/scripts/heroku_run.sh /usr/local/bin/heroku_run.sh
+
+ENTRYPOINT ["/usr/local/bin/heroku_run.sh"]

--- a/app.json
+++ b/app.json
@@ -1,0 +1,16 @@
+{
+  "environments": {
+    "review": {
+      "addons": ["jawsdb:kitefin"],
+      "env": {
+        "ECDSA_KEY": "30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a",
+        "KEY_CLAIM_TOKEN": "thisisaverylongtoken=302",
+        "METRIC_PROVIDER": "stdout",
+        "RETRIEVE_HMAC_KEY": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "success_url": "/services/ping"
+    }
+  },
+  "stack": "container",
+  "success_url": "/services/ping"
+}

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,12 @@
+build:
+  docker:
+    web: Dockerfile.heroku
+run:
+  web: |
+    /usr/local/bin/heroku_run.sh
+setup:
+  config:
+    ECDSA_KEY: 30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a
+    KEY_CLAIM_TOKEN: thisisaverylongtoken=302
+    METRIC_PROVIDER: stdout
+    RETRIEVE_HMAC_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/scripts/heroku_run.sh
+++ b/scripts/heroku_run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Parse JAWSDB_URL Env
+url=$JAWSDB_URL
+no_prot="${url/mysql:\/\//}"
+
+IFS="@"
+read -a strarr <<< "$no_prot"
+u_and_p="${strarr[0]}"
+host_and_db="${strarr[1]}"
+
+IFS="/"
+read -a strarr <<< "$host_and_db"
+host_and_port="${strarr[0]}"
+database="${strarr[1]}"
+
+IFS=":"
+read -a strarr <<< "$host_and_port"
+host="${strarr[0]}"
+
+db="${u_and_p}@tcp(${host})/${database}"
+
+DATABASE_URL=$db PORT=$PORT /usr/local/bin/server --config_file_path ./

--- a/test/app.json
+++ b/test/app.json
@@ -1,0 +1,7 @@
+{
+  "environments": {
+    "review": {
+      "addons": ["jawsdb-maria:kitefin"]
+    }
+  }
+}

--- a/test/app.json
+++ b/test/app.json
@@ -1,7 +1,0 @@
-{
-  "environments": {
-    "review": {
-      "addons": ["jawsdb-maria:kitefin"]
-    }
-  }
-}


### PR DESCRIPTION
This pull request adds Heroku PR review apps to the repository. (https://devcenter.heroku.com/articles/github-integration-review-apps)

This allows us to test against builds based on the PR code that are hosted in the cloud vs. on developer machines. The review apps make use of the `monolith` build which includes both the `submission` and `retrieval` endpoints. It also uses a SAAS DB cloud provider called JawsDB. JawsDB provides an environment variable with the connection string. As Go requires a specific connection string format, we munge the environment variable into the correct format with a script before we boot the server.

The environment variables for the app itself are the same as for the docker-compose, or local dev, environments.