### PR TITLE
remove github provider

### DIFF
--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -15,11 +15,6 @@ resource "aws_ecs_cluster" "covidshield" {
   }
 }
 
-data "github_branch" "server" {
-  repository = "covid-shield-server"
-  branch     = "master"
-}
-
 locals {
   retrieval_repo  = values(aws_ecr_repository.repository)[0].repository_url
   submission_repo = values(aws_ecr_repository.repository)[1].repository_url
@@ -35,7 +30,7 @@ data "template_file" "covidshield_key_retrieval_task" {
   template = file("task-definitions/covidshield_key_retrieval.json")
 
   vars = {
-    image                 = "${local.retrieval_repo}:${coalesce(var.github_sha, data.github_branch.server.sha)}"
+    image                 = "${local.retrieval_repo}:${var.github_sha}"
     awslogs-group         = aws_cloudwatch_log_group.covidshield.name
     awslogs-region        = var.region
     awslogs-stream-prefix = "ecs-${var.ecs_key_retrieval_name}"
@@ -157,7 +152,7 @@ data "template_file" "covidshield_key_submission_task" {
   template = file("task-definitions/covidshield_key_submission.json")
 
   vars = {
-    image                 = "${local.submission_repo}:${coalesce(var.github_sha, data.github_branch.server.sha)}"
+    image                 = "${local.submission_repo}:${var.github_sha}"
     awslogs-group         = aws_cloudwatch_log_group.covidshield.name
     awslogs-region        = var.region
     awslogs-stream-prefix = "ecs-${var.ecs_key_submission_name}"

--- a/config/terraform/aws/provider.tf
+++ b/config/terraform/aws/provider.tf
@@ -9,10 +9,6 @@ provider "aws" {
   region  = "us-east-1"
 }
 
-provider "github" {
-  owner = "cds-snc"
-}
-
 terraform {
   required_version = "> 0.12.0"
 }


### PR DESCRIPTION
The github provider is no longer required as the `github_sha` variable is always declared.