### PR TITLE
Add separate GH action for protoc

### DIFF
--- a/.github/workflows/pr-test-ci.yml
+++ b/.github/workflows/pr-test-ci.yml
@@ -25,6 +25,13 @@ jobs:
       uses: arduino/setup-protoc@7ad700d3b20e2a32b35d2c17fbdc463891608381
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Verify DB connection
+      env:
+        PORT: ${{ job.services.mysql.ports[3306] }}
+      run: |
+        while ! mysqladmin ping -h"127.0.0.1" -P"$PORT" --silent; do
+          sleep 1
+        done
     - name: Run tests
       run: |
         gem install bundler

--- a/.github/workflows/pr-test-ci.yml
+++ b/.github/workflows/pr-test-ci.yml
@@ -14,6 +14,7 @@ jobs:
           
         ports:
         - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pr-test-ci.yml
+++ b/.github/workflows/pr-test-ci.yml
@@ -20,6 +20,10 @@ jobs:
     - uses: actions/setup-ruby@v1
       with:
         ruby-version: '2.6'
+    - name: Install Protoc
+      uses: arduino/setup-protoc@7ad700d3b20e2a32b35d2c17fbdc463891608381
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests
       run: |
         gem install bundler

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -210,7 +210,7 @@ module Helper
           'KEY_CLAIM_TOKEN' => 'first-very-long-token=302:second-very-long-token=302',
           'DATABASE_URL' => DATABASE_URL,
         },
-        bin, STDERR => File.open('/dev/null')
+        bin, STDERR => :out
       )
       conn = Faraday.new(url: "http://#{addr}")
       20.times do


### PR DESCRIPTION
Closes #55 hopefully by adding in a discreet step to install the `protoc` dependency vs relying on the Ruby gem to do it.