### PR TITLE
Add feature flag for current date check feature

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,3 +26,6 @@ oneTimeCodeExpiryInMinutes: 1440
 assignmentParts: 2
 hmacKeyLength: 32
 corsAccessControlAllowOrigin: "*"
+
+# Feature flags
+disableCurrentDateCheckFeatureFlag: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,20 +10,21 @@ import (
 var log = logger.New("config")
 
 type Constants struct {
-	DefaultSubmissionServerPort    uint32
-	DefaultRetrievalServerPort     uint32
-	DefaultServerPort              uint32
-	WorkerExpirationInterval       uint32
-	MaxOneTimeCode                 int64
-	MaxConsecutiveClaimKeyFailures int
-	ClaimKeyBanDuration            uint32
-	MaxDiagnosisKeyRetentionDays   uint32
-	InitialRemainingKeys           uint32
-	EncryptionKeyValidityDays      uint32
-	OneTimeCodeExpiryInMinutes     uint32
-	AssignmentParts                int
-	HmacKeyLength                  int
-	CORSAccessControlAllowOrigin   string
+	DefaultSubmissionServerPort    			uint32
+	DefaultRetrievalServerPort     			uint32
+	DefaultServerPort              			uint32
+	WorkerExpirationInterval       			uint32
+	MaxOneTimeCode                 			int64
+	MaxConsecutiveClaimKeyFailures 			int
+	ClaimKeyBanDuration            			uint32
+	MaxDiagnosisKeyRetentionDays   			uint32
+	InitialRemainingKeys           			uint32
+	EncryptionKeyValidityDays      			uint32
+	OneTimeCodeExpiryInMinutes     			uint32
+	AssignmentParts                			int
+	HmacKeyLength                  			int
+	CORSAccessControlAllowOrigin   			string
+	DisableCurrentDateCheckFeatureFlag	bool
 }
 
 var AppConstants Constants
@@ -60,4 +61,5 @@ func setDefaults() {
 	viper.SetDefault("assignmentParts", 2)
 	viper.SetDefault("hmacKeyLength", 32)
 	viper.SetDefault("corsAccessControlAllowOrigin", "*")
+	viper.SetDefault("disableCurrentDateCheckFeatureFlag", true)
 }

--- a/pkg/server/retrieve.go
+++ b/pkg/server/retrieve.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/CovidShield/server/pkg/config"
 	"github.com/CovidShield/server/pkg/persistence"
 	pb "github.com/CovidShield/server/pkg/proto/covidshield"
 	"github.com/CovidShield/server/pkg/retrieval"
@@ -79,7 +80,7 @@ func (s *retrieveServlet) retrieve(w http.ResponseWriter, r *http.Request) resul
 	currentRSIN := pb.CurrentRollingStartIntervalNumber()
 	currentDateNumber := timemath.CurrentDateNumber()
 
-	if dateNumber == currentDateNumber {
+	if config.AppConstants.DisableCurrentDateCheckFeatureFlag == false && dateNumber == currentDateNumber {
 		return s.fail(log(ctx, err), w, "request for current date", "cannot serve data for current period for privacy reasons", http.StatusNotFound)
 	} else if dateNumber > currentDateNumber {
 		return s.fail(log(ctx, err), w, "request for future data", "cannot request future data", http.StatusNotFound)

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -11,6 +11,7 @@ require('rbnacl')
 require('mysql2')
 require('zip')
 require('securerandom')
+require('yaml')
 
 KEY_SUBMISSION_SERVER = File.expand_path('../../build/debug/key-submission --config_file_path ./', __dir__)
 KEY_RETRIEVAL_SERVER = File.expand_path('../../build/debug/key-retrieval  --config_file_path ./', __dir__)
@@ -88,7 +89,11 @@ module Helper
     def random_hash
       SecureRandom.hex(64)
     end
-    
+
+    def get_app_config
+      YAML.load_file(File.expand_path('../../config.yaml', __dir__))
+    end
+
     def new_valid_one_time_code
       resp = @sub_conn.post do |req|
         req.url('/new-key-claim')

--- a/test/retrieve_test.rb
+++ b/test/retrieve_test.rb
@@ -31,11 +31,19 @@ class RetrieveTest < MiniTest::Test
   end
 
   def test_reject_unacceptable_periods
+    
+    # Test with feature flag
+    config = get_app_config()
     resp = get_date(current_date_number)
-    assert_response(
-      resp, 404, 'text/plain; charset=utf-8',
-      body: "cannot serve data for current period for privacy reasons\n"
-    )
+
+    if config["disableCurrentDateCheckFeatureFlag"]
+      assert_response(resp, 200, 'application/zip')
+    else
+      assert_response(
+        resp, 404, 'text/plain; charset=utf-8',
+        body: "cannot serve data for current period for privacy reasons\n"
+      )
+    end
 
     resp = get_date(current_date_number - 1)
     assert_response(resp, 200, 'application/zip')


### PR DESCRIPTION
To aid rapid testing we are adding a feature flag that disables the check if you are downloading a key for the current day. 

Currently, out of privacy reason, we do not allow people to download keys that were uploaded on the current date. Usually there are no keys for the current date because the mobile app can not retrieve them from the framework unless it is running in debug mode. As a result this is another safeguard, but to aid testing we will disable it in staging.