### PR TITLE
Signature fixes

### DIFF
--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -80,7 +80,7 @@ func SerializeTo(
 		return -1, err
 	}
 
-	sig, err := signer.Sign(exportBinData)
+	sig, err := signer.Sign(append(binHeader, exportBinData...))
 	if err != nil {
 		return -1, err
 	}

--- a/pkg/retrieval/signer.go
+++ b/pkg/retrieval/signer.go
@@ -1,8 +1,8 @@
 package retrieval
 
 import (
+	"crypto"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
@@ -37,11 +37,10 @@ func NewSigner() Signer {
 }
 
 func (s *signer) Sign(data []byte) ([]byte, error) {
-	hash := sha256.Sum256(data)
-	a, b, err := ecdsa.Sign(rand.Reader, s.privateKey, hash[:])
+	digest := sha256.Sum256(data)
+	sig, err := s.privateKey.Sign(rand.Reader, digest[:], crypto.SHA256)
 	if err != nil {
 		return nil, err
 	}
-	signatureX962 := elliptic.Marshal(elliptic.P256(), a, b)
-	return signatureX962, nil
+	return sig, nil
 }

--- a/test/retrieve_test.rb
+++ b/test/retrieve_test.rb
@@ -17,8 +17,8 @@ class RetrieveTest < MiniTest::Test
     assert_equal(resp.headers['Cache-Control'], 'public, max-age=3600, max-stale=600')
     export_proto, siglist_proto = extract_zip(resp.body)
     assert_equal("EK Export v1    ", export_proto[0...16])
-    export_proto = export_proto[16..-1]
     assert_valid_signature_list(siglist_proto, export_proto)
+    export_proto = export_proto[16..-1]
     export = Covidshield::TemporaryExposureKeyExport.decode(export_proto)
     export
   end
@@ -262,13 +262,8 @@ class RetrieveTest < MiniTest::Test
     key_der = [key_hex].pack('H*')
     key = OpenSSL::PKey::EC.new(key_der)
     key.check_key
-
     digest = Digest::SHA256.digest(data)
-
-    # Why doesn't this work? Our signature is in X9.62 uncompressed form, which
-    # seems to be what OpenSSL is looking for, but we get "nested asn1 error".
-    puts("WARN: not verifying signature")
-    # key.dsa_verify_asn1(digest, signature)
+    key.dsa_verify_asn1(digest, signature)
   end
 
   def assert_keys(export, keys, region:, date_number:)


### PR DESCRIPTION
Based on observations that the underlying frameworks are rejecting the signatures of ZIP file I have made the following changes:

1. Changed the signing functionality from X962 signature to the implementation found on the Google reference server

https://github.com/google/exposure-notifications-server/blob/1208580e92e3a9f23d85eb570fbdff8d1f6e7a00/internal/export/exportfile.go#L217-L224

2. Included the header payload as part of the signed payload - another pointer from the the Google reference server

https://github.com/google/exposure-notifications-server/blob/1208580e92e3a9f23d85eb570fbdff8d1f6e7a00/internal/export/exportfile.go#L178

3. Adjusted the Ruby tests, which now verify the signature. 

I validated the signature using this tool: https://github.com/google/exposure-notifications-server/tree/main/examples/export#verifying-an-export

ex:
```
$ go run ./tools/unwrap-signature/ --in=export.sig --out=sigRaw
2020/07/05 18:27:52 Data:
signatures:{signature_info:{verification_key_version:"v1"  verification_key_id:"302"  signature_algorithm:"1.2.840.10045.4.3.2"}  batch_num:1  batch_size:1  signature:"0F\x02!\x00\xc7ߠ\xf3\x1f\\\x81\xfeؘ3\xda\xfc\xec&sB\x10\xd13\xb7G\xb0\xca\xec\xd1\r\xe6\xa2J\x1dc\x02!\x00\xb7\xd77\xc5Q\xaf\xbe!b\r\xbe\xf1\x07\xf8\xd7\xc1׸DPO\xba\x06\xa8\x1e\xa9\xf99\xc4\xe0\xe4\x05"}
```
```
$ openssl dgst -sha256 -verify public.pem -signature sigRaw export.bin
Verified OK
```