### PR TITLE
Fix a bug where a transaction was not closed

### DIFF
--- a/pkg/persistence/queries.go
+++ b/pkg/persistence/queries.go
@@ -202,6 +202,9 @@ func registerDiagnosisKeys(db *sql.DB, appPubKey *[32]byte, keys []*pb.Temporary
 	}
 
 	if remainingKeys == 0 {
+		if err := tx.Rollback(); err != nil {
+			return err
+		}
 		return ErrKeyConsumed
 	}
 


### PR DESCRIPTION
Previous to this bug if you tried to submit keys to a one time code that had reached a 0 upload key remaining, you could leave the transaction open, locking the database.