### PR TITLE
Add permissions for Alerts to send to SNS topics

### DIFF
--- a/config/terraform/aws/kms.tf
+++ b/config/terraform/aws/kms.tf
@@ -28,7 +28,20 @@ resource "aws_kms_key" "cw" {
         "kms:Describe*"
       ],
       "Resource": "*"
-    }  
+    },
+    {
+      "Sid": "Allow_CloudWatch_for_CMK",
+      "Effect": "Allow",
+      "Principal": {
+          "Service":[
+              "cloudwatch.amazonaws.com"
+          ]
+      },
+      "Action": [
+          "kms:Decrypt","kms:GenerateDataKey"
+      ],
+      "Resource": "*"
+    }
   ]
 }
 EOF


### PR DESCRIPTION
Currently alarms are not sending messages to the SNS topics because they can't access the default KMS key. Solution is referenced here: https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/