### PR TITLE
updated the error codes for /new-key-claim endpoint that generates the 8 digit code

### DIFF
--- a/pkg/server/keyclaim.go
+++ b/pkg/server/keyclaim.go
@@ -50,7 +50,7 @@ func (s *keyClaimServlet) newKeyClaim(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method != "POST" {
 		log(ctx, nil).WithField("method", r.Method).Info("disallowed method")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -68,7 +68,7 @@ func (s *keyClaimServlet) newKeyClaim(w http.ResponseWriter, r *http.Request) {
 		count, err := s.db.CheckHashID(hashID)
 		if count > 0 {
 			log(ctx, err).WithField("header", hdr).Info("hashID used")
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			http.Error(w, "forbidden", http.StatusForbidden)
 			return
 		}
 	}

--- a/test/new_key_claim_hash_id_test.rb
+++ b/test/new_key_claim_hash_id_test.rb
@@ -17,7 +17,7 @@ class NewKeyClaimhashIDTest < MiniTest::Test
 
     %w[get patch delete put].each do |meth|
       resp = @sub_conn.send(meth, "/new-key-claim/#{hash_id}")
-      assert_response(resp, 405, 'text/plain; charset=utf-8', body: "method not allowed\n")
+      assert_response(resp, 401, 'text/plain; charset=utf-8', body: "unauthorized\n")
     end
 
     resp = @sub_conn.post do |req|
@@ -52,7 +52,7 @@ class NewKeyClaimhashIDTest < MiniTest::Test
       req.url("/new-key-claim/#{hash_id}")
       req.headers['Authorization'] = 'Bearer second-very-long-token'
     end
-    assert_response(resp, 401, 'text/plain; charset=utf-8', body: "unauthorized\n")
+    assert_response(resp, 403, 'text/plain; charset=utf-8', body: "forbidden\n")
 
   end
 end

--- a/test/new_key_claim_test.rb
+++ b/test/new_key_claim_test.rb
@@ -31,7 +31,7 @@ class NewKeyClaimTest < MiniTest::Test
 
     %w[get patch delete put].each do |meth|
       resp = @sub_conn.send(meth, '/new-key-claim')
-      assert_response(resp, 405, 'text/plain; charset=utf-8', body: "method not allowed\n")
+      assert_response(resp, 401, 'text/plain; charset=utf-8', body: "unauthorized\n")
     end
   end
 end


### PR DESCRIPTION
closes #98 
This pull request is to make the error codes/error messages generic for  "/new-key-claim" endpoint that generates the 8 digit code.
