### PR TITLE
ignore subnet id's in nacl

### DIFF
--- a/config/terraform/aws/networking.tf
+++ b/config/terraform/aws/networking.tf
@@ -398,6 +398,11 @@ resource "aws_default_network_acl" "covidshield" {
     to_port    = 0
   }
 
+  // See https://www.terraform.io/docs/providers/aws/r/default_network_acl.html#managing-subnets-in-the-default-network-acl
+  lifecycle {
+    ignore_changes = [subnet_ids]
+  }
+
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
   }


### PR DESCRIPTION
subnet id's in the nacl keep showing up in the TF plan due to https://www.terraform.io/docs/providers/aws/r/default_network_acl.html#managing-subnets-in-the-default-network-acl