### PR TITLE
Variable rolling period

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,8 +10,9 @@ claimKeyBanDuration: 1
 # so 14 days ago is the oldest data.
 maxDiagnosisKeyRetentionDays: 15
 
-# A generated keypair can upload up to 28 keys (14 on day 1, plus 14 subsequent days)
-initialRemainingKeys: 28
+# A generated keypair can upload up to 43 keys (15 on day 1, plus 2 for 14 subsequent days
+# if they upload once per day)
+initialRemainingKeys: 43
 
 # (Legal requirement: <21)
 # When we assign an Application Public Key to a server keypair, we reset the

--- a/pkg/proto/covidshield/defs.go
+++ b/pkg/proto/covidshield/defs.go
@@ -15,7 +15,7 @@ const (
 	// Number of ENIntervalNumber (600s long) after
 	// which the Key is rolled.
 	// 144 * 600 = 86400 (1 day)
-	TEKRollingPeriod = 144
+	MaxTEKRollingPeriod = 144
 	MaxKeysInUpload  = 14
 )
 
@@ -44,5 +44,5 @@ func IntoNonce(bytes []byte) (*[NonceLength]byte, error) {
 func CurrentRollingStartIntervalNumber() int32 {
 	epochTime := time.Now().Unix()
 	intervalNumber := int32(epochTime / (60 * 10))
-	return (intervalNumber / TEKRollingPeriod) * TEKRollingPeriod
+	return (intervalNumber / MaxTEKRollingPeriod) * MaxTEKRollingPeriod
 }

--- a/pkg/proto/covidshield/defs.go
+++ b/pkg/proto/covidshield/defs.go
@@ -16,7 +16,7 @@ const (
 	// which the Key is rolled.
 	// 144 * 600 = 86400 (1 day)
 	MaxTEKRollingPeriod = 144
-	MaxKeysInUpload  = 14
+	MaxKeysInUpload  = 28
 )
 
 func IntoKey(bytes []byte) (*[KeyLength]byte, error) {

--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -243,9 +243,9 @@ func validateKeys(ctx context.Context, w http.ResponseWriter, keys []*pb.Tempora
 	max := ints[len(ints)-1]
 	maxEnd := max + 144
 
-	if maxEnd-min > (144 * 14) {
+	if maxEnd-min > (144 * 15) {
 		requestError(
-			ctx, w, nil, "sequence of rollingStartIntervalNumbers exceeds 14 days",
+			ctx, w, nil, "sequence of rollingStartIntervalNumbers exceeds 15 days",
 			http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_INVALID_ROLLING_START_INTERVAL_NUMBER),
 		)
 		return false

--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -243,6 +243,8 @@ func validateKeys(ctx context.Context, w http.ResponseWriter, keys []*pb.Tempora
 	max := ints[len(ints)-1]
 	maxEnd := max + 144
 
+	// Changed from 14 to 15 because you can have a case where you submit for the
+	// past 14 days plus part of today
 	if maxEnd-min > (144 * 15) {
 		requestError(
 			ctx, w, nil, "sequence of rollingStartIntervalNumbers exceeds 15 days",

--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -188,7 +188,7 @@ func (s *uploadServlet) upload(w http.ResponseWriter, r *http.Request) {
 }
 
 func validateKey(ctx context.Context, w http.ResponseWriter, key *pb.TemporaryExposureKey) bool {
-	if key.GetRollingPeriod() != 144 {
+	if key.GetRollingPeriod() < 1 || key.GetRollingPeriod() > 144{
 		requestError(
 			ctx, w, nil, "missing or invalid rollingPeriod",
 			http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_INVALID_ROLLING_PERIOD),
@@ -251,17 +251,21 @@ func validateKeys(ctx context.Context, w http.ResponseWriter, keys []*pb.Tempora
 		return false
 	}
 
-	lastEnd := 0
-	for _, rsn := range ints {
-		if rsn < lastEnd {
-			requestError(
-				ctx, w, nil, "overlapping or duplicate rollingStartIntervalNumbers",
-				http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_INVALID_ROLLING_START_INTERVAL_NUMBER),
-			)
-			return false
-		}
-		lastEnd = rsn + 144
-	}
+	// if len(ints) > 1 {
+	//	lastEnd := 0
+	//	rollingPeriod := ints[1] - ints[0]
+		
+	//	for _, rsn := range ints {
+	//		if rsn < lastEnd {
+	//			requestError(
+	//				ctx, w, nil, "overlapping or duplicate rollingStartIntervalNumbers",
+	//				http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_INVALID_ROLLING_START_INTERVAL_NUMBER),
+	//			)
+	//			return false
+	//		}
+	//		lastEnd = rsn + rollingPeriod
+	//	}
+	// }
 
 	return true
 }

--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -251,21 +251,5 @@ func validateKeys(ctx context.Context, w http.ResponseWriter, keys []*pb.Tempora
 		return false
 	}
 
-	// if len(ints) > 1 {
-	//	lastEnd := 0
-	//	rollingPeriod := ints[1] - ints[0]
-		
-	//	for _, rsn := range ints {
-	//		if rsn < lastEnd {
-	//			requestError(
-	//				ctx, w, nil, "overlapping or duplicate rollingStartIntervalNumbers",
-	//				http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_INVALID_ROLLING_START_INTERVAL_NUMBER),
-	//			)
-	//			return false
-	//		}
-	//		lastEnd = rsn + rollingPeriod
-	//	}
-	// }
-
 	return true
 }

--- a/pkg/timemath/timemath.go
+++ b/pkg/timemath/timemath.go
@@ -33,7 +33,7 @@ func HourNumberPlusDays(hourNumber uint32, days int) uint32 {
 }
 
 func RollingStartIntervalNumberPlusDays(rsin int32, days int) int32 {
-	return int32(int(rsin) + days*pb.TEKRollingPeriod)
+	return int32(int(rsin) + days*pb.MaxTEKRollingPeriod)
 }
 
 func CurrentDateNumber() uint32 {

--- a/test/upload_test.rb
+++ b/test/upload_test.rb
@@ -135,10 +135,6 @@ class UploadTest < MiniTest::Test
     random_tek_interval = rand(100...144)
     resp = post_teks(teks.map { |tek| tek.rolling_period = random_tek_interval; tek })
     assert_result(resp, 200, :NONE)
-
-    # only one tek shifted off of midnight
-    # resp = post_teks(teks.map.with_index { |tek, index| tek.rolling_start_interval_number += 1 if index == 4; tek })
-    # assert_result(resp, 400, :INVALID_ROLLING_START_INTERVAL_NUMBER)
   end
 
   def test_invalid_timestamp

--- a/test/upload_test.rb
+++ b/test/upload_test.rb
@@ -103,7 +103,6 @@ class UploadTest < MiniTest::Test
 
     # rolling_period missing, too high, too low
     assert_tek_fails(:INVALID_ROLLING_PERIOD, rolling_period: 0)
-    assert_tek_fails(:INVALID_ROLLING_PERIOD, rolling_period: 143)
     assert_tek_fails(:INVALID_ROLLING_PERIOD, rolling_period: 145)
 
     # risk level too high, too low
@@ -132,9 +131,14 @@ class UploadTest < MiniTest::Test
     resp = post_teks(teks.map { |tek| tek.rolling_start_interval_number += 1; tek })
     assert_result(resp, 200, :NONE)
 
+    # randomize tek intervals below 144
+    random_tek_interval = rand(100...144)
+    resp = post_teks(teks.map { |tek| tek.rolling_period = random_tek_interval; tek })
+    assert_result(resp, 200, :NONE)
+
     # only one tek shifted off of midnight
-    resp = post_teks(teks.map.with_index { |tek, index| tek.rolling_start_interval_number += 1 if index == 4; tek })
-    assert_result(resp, 400, :INVALID_ROLLING_START_INTERVAL_NUMBER)
+    # resp = post_teks(teks.map.with_index { |tek, index| tek.rolling_start_interval_number += 1 if index == 4; tek })
+    # assert_result(resp, 400, :INVALID_ROLLING_START_INTERVAL_NUMBER)
   end
 
   def test_invalid_timestamp


### PR DESCRIPTION
This PR allows keys to have a `rollingPeriod` less than 144. The use case for this may be when users would like to upload todays key, in which case the framework will provide two keys for that day with the same `rollingStartIntervalNumber`. ex:

```
{
    keyData: 'ATtHjF3BQbJhcQprMWjTkg==',
    rollingPeriod: 104,
    rollingStartIntervalNumber: 2656800,
    transmissionRiskLevel: 0,
  },
  {
    keyData: 'IBjwbMPl7526ljC3DcBEGQ==',
    rollingPeriod: 142,
    rollingStartIntervalNumber: 2656800,
    transmissionRiskLevel: 0,
  }
```

This requires the following changes:

- Increasing the maximum number of keys uploaded per one time code to 43. (On day 0 you upload 14 keys for the previous  days, and one key for half of day 0, plus 28 keys for the consecutive 14 days - assuming you upload once a day for the next 14 days, in which case you generate two keys per day)
- Remove the check for `rollingPeriod` being not equal to 144.
- Increase the number of allowed keys per payload (28 for 14 days if 2 keys are uploaded per day)