### PR TITLE
BVC-71 :: TOUTOC bug in new-key-claim endpoint

### DIFF
--- a/pkg/persistence/db.go
+++ b/pkg/persistence/db.go
@@ -37,7 +37,6 @@ type Conn interface {
 	FetchKeysForDateNumber(string, uint32, int32) ([]*pb.TemporaryExposureKey, error)
 	StoreKeys(*[32]byte, []*pb.TemporaryExposureKey) error
 	NewKeyClaim(string, string, string) (string, error)
-	CheckHashID(string) (int64, error)
 	ClaimKey(string, []byte) ([]byte, error)
 	PrivForPub([]byte) ([]byte, error)
 
@@ -142,6 +141,10 @@ func (c *conn) ClaimKey(oneTimeCode string, appPublicKey []byte) ([]byte, error)
 	return claimKey(c.db, oneTimeCode, appPublicKey)
 }
 
+// ErrHashIDClaimed is returned when the client tries to get a new code for a 
+// HashID that has laready used the code
+var ErrHashIDClaimed = errors.New("HashID claimed")
+
 const maxOneTimeCode = 1e8
 
 func (c *conn) NewKeyClaim(region, originator, hashID string) (string, error) {
@@ -164,6 +167,8 @@ func (c *conn) NewKeyClaim(region, originator, hashID string) (string, error) {
 		err = persistEncryptionKey(c.db, region, originator, hashID, pub, priv, oneTimeCode)
 		if err == nil {
 			return oneTimeCode, nil
+		} else if strings.Contains(err.Error(), "used hashID found") {
+			return "", ErrHashIDClaimed
 		} else if strings.Contains(err.Error(), "Duplicate entry") {
 			log(nil, err).Warn("duplicate one_time_code")
 		} else {
@@ -171,10 +176,6 @@ func (c *conn) NewKeyClaim(region, originator, hashID string) (string, error) {
 		}
 	}
 	return "", err
-}
-
-func (c *conn) CheckHashID(hashID string) (int64, error) {
-	return checkHashID(c.db, hashID)
 }
 
 func (c *conn) PrivForPub(pub []byte) ([]byte, error) {

--- a/pkg/persistence/db.go
+++ b/pkg/persistence/db.go
@@ -142,7 +142,7 @@ func (c *conn) ClaimKey(oneTimeCode string, appPublicKey []byte) ([]byte, error)
 }
 
 // ErrHashIDClaimed is returned when the client tries to get a new code for a 
-// HashID that has laready used the code
+// HashID that has already used the code
 var ErrHashIDClaimed = errors.New("HashID claimed")
 
 const maxOneTimeCode = 1e8

--- a/pkg/persistence/queries.go
+++ b/pkg/persistence/queries.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -141,12 +142,50 @@ func claimKey(db *sql.DB, oneTimeCode string, appPublicKey []byte) ([]byte, erro
 }
 
 func persistEncryptionKey(db *sql.DB, region, originator, hashID string, pub *[32]byte, priv *[32]byte, oneTimeCode string) error {
-	_, err := db.Exec(
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+
+	if len(hashID) > 0 {
+		var one_time_code string
+		row := tx.QueryRow("SELECT one_time_code FROM encryption_keys WHERE hash_id = ? FOR UPDATE", hashID)
+
+		switch err := row.Scan(&one_time_code); {
+		case err == sql.ErrNoRows: // no hashID found
+		case len(one_time_code) == 0: // used hashID found
+			if err := tx.Rollback(); err != nil {
+				return err
+			}
+			return errors.New("used hashID found")
+		case len(one_time_code) > 0: // un-used hashID found
+			_, err = tx.Exec(`DELETE FROM encryption_keys WHERE hash_id = ? AND one_time_code IS NOT NULL`, hashID)
+			if err != nil {
+				if err := tx.Rollback(); err != nil {
+					return err
+				}
+			}
+		default:
+		}
+	}
+	
+	_, err = tx.Exec(
 		`INSERT INTO encryption_keys
 			(region, originator, hash_id, server_private_key, server_public_key, one_time_code, remaining_keys)
 			VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		region, originator, hashID, priv[:], pub[:], oneTimeCode, config.AppConstants.InitialRemainingKeys,
 	)
+	
+	if err != nil {
+		if err := tx.Rollback(); err != nil {
+			return err
+		}
+	}
+	
+	if err = tx.Commit(); err != nil {
+		return err
+	}
+
 	return err
 }
 
@@ -305,27 +344,6 @@ func checkClaimKeyBan(db queryRower, identifier string) (triesRemaining int, ban
 	}
 
 	return triesRemaining, banDuration, nil
-}
-
-func checkHashID(db *sql.DB, identifier string) (int64, error) {
-	var one_time_code string
-
-	row := db.QueryRow("SELECT one_time_code FROM encryption_keys WHERE hash_id = ?", identifier)
-
-	switch err := row.Scan(&one_time_code); {
-	case err == sql.ErrNoRows: // no hashID found
-		return 0, err
-	case len(one_time_code) == 0: // used hashID found
-		return 1, err
-	case len(one_time_code) > 0: // un-used hashID found
-		_, err = db.Exec(`DELETE FROM encryption_keys WHERE hash_id = ? AND one_time_code IS NOT NULL`, identifier)
-		if err != nil {
-			return 1, err
-		}
-		return 0, err
-	default:
-		return 1, err
-	}
 }
 
 func registerClaimKeySuccess(db *sql.DB, identifier string) error {

--- a/pkg/persistence/queries.go
+++ b/pkg/persistence/queries.go
@@ -153,6 +153,12 @@ func persistEncryptionKey(db *sql.DB, region, originator, hashID string, pub *[3
 
 		switch err := row.Scan(&one_time_code); {
 		case err == sql.ErrNoRows: // no hashID found
+		case err != nil:
+			log(nil, err).Error(err.Error())
+			if err := tx.Rollback(); err != nil {
+				return err
+			}
+			return err
 		case len(one_time_code) == 0: // used hashID found
 			if err := tx.Rollback(); err != nil {
 				return err

--- a/pkg/server/keyclaim.go
+++ b/pkg/server/keyclaim.go
@@ -64,15 +64,6 @@ func (s *keyClaimServlet) newKeyClaim(w http.ResponseWriter, r *http.Request) {
 
 	hashID := vars["hashID"]
 
-	if len(hashID) != 0 {
-		count, err := s.db.CheckHashID(hashID)
-		if count > 0 {
-			log(ctx, err).WithField("header", hdr).Info("hashID used")
-			http.Error(w, "forbidden", http.StatusForbidden)
-			return
-		}
-	}
-
 	keyClaim, err := s.db.NewKeyClaim(region, originator, hashID)
 	if err == persistence.ErrHashIDClaimed {
 		log(ctx, err).WithField("header", hdr).Info("hashID used")

--- a/pkg/server/keyclaim.go
+++ b/pkg/server/keyclaim.go
@@ -63,18 +63,12 @@ func (s *keyClaimServlet) newKeyClaim(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hashID := vars["hashID"]
-
-	if len(hashID) != 0 {
-		count, err := s.db.CheckHashID(hashID)
-		if count > 0 {
-			log(ctx, err).WithField("header", hdr).Info("hashID used")
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-	}
-
 	keyClaim, err := s.db.NewKeyClaim(region, originator, hashID)
-	if err != nil {
+	if err == persistence.ErrHashIDClaimed {
+		log(ctx, err).WithField("header", hdr).Info("hashID used")
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	} else if err != nil {
 		log(ctx, err).Error("error constructing new key claim")
 		http.Error(w, "server error", http.StatusInternalServerError)
 		return

--- a/test/new_key_claim_hash_id_test.rb
+++ b/test/new_key_claim_hash_id_test.rb
@@ -52,7 +52,7 @@ class NewKeyClaimhashIDTest < MiniTest::Test
       req.url("/new-key-claim/#{hash_id}")
       req.headers['Authorization'] = 'Bearer second-very-long-token'
     end
-    assert_response(resp, 401, 'text/plain; charset=utf-8', body: "unauthorized\n")
+    assert_response(resp, 403, 'text/plain; charset=utf-8', body: "forbidden\n")
 
   end
 end


### PR DESCRIPTION
Closes #147. 

This PR changes the HashID logic by incorporating all the required queries into a single transaction with a "FOR UPDATE" lock. This removes the race condition where by two one time codes could have the same HashIDs.