### PR TITLE
Add app based log metrics

### DIFF
--- a/config/terraform/aws/metrics.tf
+++ b/config/terraform/aws/metrics.tf
@@ -43,8 +43,8 @@ resource "aws_cloudwatch_log_metric_filter" "UnclaimedOneTimeCodeTotal" {
   log_group_name = aws_cloudwatch_log_group.covidshield.name
 
   metric_transformation {
-    name      = "CovidShield"
-    namespace = "UnclaimedOneTimeCodeTotal"
+    name      = "UnclaimedOneTimeCodeTotal"
+    namespace = "CovidShield"
     value     = "$.updates[${count.index}].sum"
   }
 }
@@ -57,8 +57,8 @@ resource "aws_cloudwatch_log_metric_filter" "ClaimedOneTimeCodeTotal" {
   log_group_name = aws_cloudwatch_log_group.covidshield.name
 
   metric_transformation {
-    name      = "CovidShield"
-    namespace = "ClaimedOneTimeCodeTotal"
+    name      = "ClaimedOneTimeCodeTotal"
+    namespace = "CovidShield"
     value     = "$.updates[${count.index}].sum"
   }
 }
@@ -71,8 +71,8 @@ resource "aws_cloudwatch_log_metric_filter" "DiagnosisKeyTotal" {
   log_group_name = aws_cloudwatch_log_group.covidshield.name
 
   metric_transformation {
-    name      = "CovidShield"
-    namespace = "DiagnosisKeyTotal"
+    name      = "DiagnosisKeyTotal"
+    namespace = "CovidShield"
     value     = "$.updates[${count.index}].sum"
   }
 }

--- a/config/terraform/aws/metrics.tf
+++ b/config/terraform/aws/metrics.tf
@@ -1,0 +1,78 @@
+# Why do we have a count of 8 you ask?
+#
+# App metrics are logged as an array in JSON ex:
+#
+# {
+#   "time": "2020-07-09T22:06:18.913005245Z",
+#   "updates": [
+#     {
+#       "name": "covidshield.system.memory.free",
+#       "min": 16060346368,
+#       "max": 16060346368,
+#       "sum": 16060346368,
+#       "count": 1
+#     },
+#     {
+#       "name": "covidshield.system.cpu.percent",
+#       "min": 0.5494505494505346,
+#       "max": 0.5494505494505346,
+#       "sum": 0.5494505494505346,
+#       "count": 1
+#     },
+#    {
+#       "name": "covidshield.app.claimed_one_time_codes.total",
+#       "min": 403,
+#       "max": 403,
+#       "sum": 403,
+#       "count": 1
+#    }
+#    ...
+# }
+#
+# The problem is that this array has 8 items and AWS Cloudwatch can't filter on
+# a variable position. ex: {$.updates[*].name = ... The order of the array
+# is also always different, so we need a metric for each possible position it
+# can be in. :/
+
+
+resource "aws_cloudwatch_log_metric_filter" "UnclaimedOneTimeCodeTotal" {
+  count = 8
+
+  name           = "UnclaimedOneTimeCodeTotal${count.index}"
+  pattern        = "{$.updates[${count.index}].name = \"covidshield.app.unclaimed_one_time_codes.total\"}"
+  log_group_name = aws_cloudwatch_log_group.covidshield.name
+
+  metric_transformation {
+    name      = "CovidShield"
+    namespace = "UnclaimedOneTimeCodeTotal"
+    value     = "$.updates[${count.index}].sum"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "ClaimedOneTimeCodeTotal" {
+  count = 8
+
+  name           = "ClaimedOneTimeCodeTotal${count.index}"
+  pattern        = "{$.updates[${count.index}].name = \"covidshield.app.claimed_one_time_codes.total\"}"
+  log_group_name = aws_cloudwatch_log_group.covidshield.name
+
+  metric_transformation {
+    name      = "CovidShield"
+    namespace = "ClaimedOneTimeCodeTotal"
+    value     = "$.updates[${count.index}].sum"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "DiagnosisKeyTotal" {
+  count = 8
+
+  name           = "DiagnosisKeyTotal${count.index}"
+  pattern        = "{$.updates[${count.index}].name = \"covidshield.app.diagnosis_keys.total\"}"
+  log_group_name = aws_cloudwatch_log_group.covidshield.name
+
+  metric_transformation {
+    name      = "CovidShield"
+    namespace = "DiagnosisKeyTotal"
+    value     = "$.updates[${count.index}].sum"
+  }
+}

--- a/config/terraform/aws/metrics.tf
+++ b/config/terraform/aws/metrics.tf
@@ -31,7 +31,7 @@
 #
 # The problem is that this array has 8 items and AWS Cloudwatch can't filter on
 # a variable position. ex: {$.updates[*].name = ... The order of the array
-# is also always different, so we need a metric for each possible position it
+# is also always different, so we need a metric filter for each possible position
 # can be in. :/
 
 


### PR DESCRIPTION
Adds additional application based log metrics.

Why do we have a count of 8 AWS metrics per metric you ask?

App metrics are logged as an array in JSON ex:

```
{
  "time": "2020-07-09T22:06:18.913005245Z",
  "updates": [
    {
      "name": "covidshield.system.memory.free",
      "min": 16060346368,
      "max": 16060346368,
      "sum": 16060346368,
      "count": 1
    },
    {
      "name": "covidshield.system.cpu.percent",
      "min": 0.5494505494505346,
      "max": 0.5494505494505346,
      "sum": 0.5494505494505346,
      "count": 1
    },
   {
      "name": "covidshield.app.claimed_one_time_codes.total",
      "min": 403,
      "max": 403,
      "sum": 403,
      "count": 1
   }
   ...
}
```

The problem is that this array has 8 items and AWS Cloudwatch can't filter on a variable position. ex: `{$.updates[*].name = ...` The order of the array is also always different, so we need a metric filter for each possible position can be in. :/