### PR TITLE
add taskdef back to ecs service

### DIFF
--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -67,6 +67,7 @@ resource "aws_ecs_service" "covidshield_key_retrieval" {
 
   name             = var.ecs_key_retrieval_name
   cluster          = aws_ecs_cluster.covidshield.id
+  task_definition  = aws_ecs_task_definition.covidshield_key_retrieval.arn
   launch_type      = "FARGATE"
   platform_version = "1.4.0"
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
@@ -198,6 +199,7 @@ resource "aws_ecs_service" "covidshield_key_submission" {
 
   name             = var.ecs_key_submission_name
   cluster          = aws_ecs_cluster.covidshield.id
+  task_definition  = aws_ecs_task_definition.covidshield_key_submission.arn
   launch_type      = "FARGATE"
   platform_version = "1.4.0"
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)


### PR DESCRIPTION
`aws_ecs_service` resource requires a task definition intially.