### PR TITLE
default old deploy termination to 1 and allow overriding via env var

### DIFF
--- a/config/terraform/aws/codedeploy.tf
+++ b/config/terraform/aws/codedeploy.tf
@@ -1,21 +1,23 @@
 module "covid-shield-retrieval" {
-  source                         = "./modules/codedeploy"
-  codedeploy_service_role_arn    = aws_iam_role.codedeploy.arn
-  action_on_timeout              = var.manual_deploy_enabled ? "STOP_DEPLOYMENT" : "CONTINUE_DEPLOYMENT"
-  cluster_name                   = aws_ecs_cluster.covidshield.name
-  ecs_service_name               = aws_ecs_service.covidshield_key_retrieval.name
-  lb_listener_arns               = [aws_lb_listener.covidshield_key_retrieval.arn]
-  aws_lb_target_group_blue_name  = aws_lb_target_group.covidshield_key_retrieval.name
-  aws_lb_target_group_green_name = aws_lb_target_group.covidshield_key_retrieval_2.name
+  source                           = "./modules/codedeploy"
+  codedeploy_service_role_arn      = aws_iam_role.codedeploy.arn
+  action_on_timeout                = var.manual_deploy_enabled ? "STOP_DEPLOYMENT" : "CONTINUE_DEPLOYMENT"
+  termination_wait_time_in_minutes = var.termination_wait_time_in_minutes
+  cluster_name                     = aws_ecs_cluster.covidshield.name
+  ecs_service_name                 = aws_ecs_service.covidshield_key_retrieval.name
+  lb_listener_arns                 = [aws_lb_listener.covidshield_key_retrieval.arn]
+  aws_lb_target_group_blue_name    = aws_lb_target_group.covidshield_key_retrieval.name
+  aws_lb_target_group_green_name   = aws_lb_target_group.covidshield_key_retrieval_2.name
 }
 
 module "covid-shield-submission" {
-  source                         = "./modules/codedeploy"
-  codedeploy_service_role_arn    = aws_iam_role.codedeploy.arn
-  action_on_timeout              = var.manual_deploy_enabled ? "STOP_DEPLOYMENT" : "CONTINUE_DEPLOYMENT"
-  cluster_name                   = aws_ecs_cluster.covidshield.name
-  ecs_service_name               = aws_ecs_service.covidshield_key_submission.name
-  lb_listener_arns               = [aws_lb_listener.covidshield_key_submission.arn]
-  aws_lb_target_group_blue_name  = aws_lb_target_group.covidshield_key_submission.name
-  aws_lb_target_group_green_name = aws_lb_target_group.covidshield_key_submission_2.name
+  source                           = "./modules/codedeploy"
+  codedeploy_service_role_arn      = aws_iam_role.codedeploy.arn
+  action_on_timeout                = var.manual_deploy_enabled ? "STOP_DEPLOYMENT" : "CONTINUE_DEPLOYMENT"
+  termination_wait_time_in_minutes = var.termination_wait_time_in_minutes
+  cluster_name                     = aws_ecs_cluster.covidshield.name
+  ecs_service_name                 = aws_ecs_service.covidshield_key_submission.name
+  lb_listener_arns                 = [aws_lb_listener.covidshield_key_submission.arn]
+  aws_lb_target_group_blue_name    = aws_lb_target_group.covidshield_key_submission.name
+  aws_lb_target_group_green_name   = aws_lb_target_group.covidshield_key_submission_2.name
 }

--- a/config/terraform/aws/modules/codedeploy/main.tf
+++ b/config/terraform/aws/modules/codedeploy/main.tf
@@ -21,7 +21,7 @@ resource "aws_codedeploy_deployment_group" "app" {
 
     terminate_blue_instances_on_deployment_success {
       action                           = "TERMINATE"
-      termination_wait_time_in_minutes = 5
+      termination_wait_time_in_minutes = var.termination_wait_time_in_minutes
     }
   }
 

--- a/config/terraform/aws/modules/codedeploy/variables.tf
+++ b/config/terraform/aws/modules/codedeploy/variables.tf
@@ -8,6 +8,11 @@ variable "action_on_timeout" {
   description = "Action to take on deployment timeout"
 }
 
+variable "termination_wait_time_in_minutes" {
+  type        = number
+  description = "minutes to wait to terminate old deploy"
+}
+
 variable "cluster_name" {
   type        = string
   description = "The ECS cluster name"

--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -79,6 +79,12 @@ variable "manual_deploy_enabled" {
   default = false
 }
 
+variable "termination_wait_time_in_minutes" {
+  type        = number
+  description = "minutes to wait to terminate old deploy"
+  default     = 1
+}
+
 # Task Key Submission
 variable "ecs_key_submission_name" {
   type = string


### PR DESCRIPTION
Allow the termination_wait_time_in_minutes to be overridden by env var and set default to 1min