### PR TITLE
Add download entire period bundle feature

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -30,3 +30,4 @@ corsAccessControlAllowOrigin: "*"
 
 # Feature flags
 disableCurrentDateCheckFeatureFlag: true
+enableEntirePeriodBundle: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,7 @@ type Constants struct {
 	HmacKeyLength                  			int
 	CORSAccessControlAllowOrigin   			string
 	DisableCurrentDateCheckFeatureFlag	bool
+	EnableEntirePeriodBundle						bool
 }
 
 var AppConstants Constants
@@ -62,4 +63,5 @@ func setDefaults() {
 	viper.SetDefault("hmacKeyLength", 32)
 	viper.SetDefault("corsAccessControlAllowOrigin", "*")
 	viper.SetDefault("disableCurrentDateCheckFeatureFlag", true)
+	viper.SetDefault("enableEntirePeriodBundle", false)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,22 +10,22 @@ import (
 var log = logger.New("config")
 
 type Constants struct {
-	DefaultSubmissionServerPort    			uint32
-	DefaultRetrievalServerPort     			uint32
-	DefaultServerPort              			uint32
-	WorkerExpirationInterval       			uint32
-	MaxOneTimeCode                 			int64
-	MaxConsecutiveClaimKeyFailures 			int
-	ClaimKeyBanDuration            			uint32
-	MaxDiagnosisKeyRetentionDays   			uint32
-	InitialRemainingKeys           			uint32
-	EncryptionKeyValidityDays      			uint32
-	OneTimeCodeExpiryInMinutes     			uint32
-	AssignmentParts                			int
-	HmacKeyLength                  			int
-	CORSAccessControlAllowOrigin   			string
-	DisableCurrentDateCheckFeatureFlag	bool
-	EnableEntirePeriodBundle						bool
+	DefaultSubmissionServerPort        uint32
+	DefaultRetrievalServerPort         uint32
+	DefaultServerPort                  uint32
+	WorkerExpirationInterval           uint32
+	MaxOneTimeCode                     int64
+	MaxConsecutiveClaimKeyFailures     int
+	ClaimKeyBanDuration                uint32
+	MaxDiagnosisKeyRetentionDays       uint32
+	InitialRemainingKeys               uint32
+	EncryptionKeyValidityDays          uint32
+	OneTimeCodeExpiryInMinutes         uint32
+	AssignmentParts                    int
+	HmacKeyLength                      int
+	CORSAccessControlAllowOrigin       string
+	DisableCurrentDateCheckFeatureFlag bool
+	EnableEntirePeriodBundle           bool
 }
 
 var AppConstants Constants

--- a/pkg/server/retrieve.go
+++ b/pkg/server/retrieve.go
@@ -72,7 +72,7 @@ func (s *retrieveServlet) retrieve(w http.ResponseWriter, r *http.Request) resul
 	var endTimestamp time.Time
 	var dateNumber uint32
 
-	if vars["day"] == "00000" {
+	if config.AppConstants.EnableEntirePeriodBundle == true && vars["day"] == "00000" {
 
 		endDate := timemath.CurrentDateNumber() - 1
 		startDate := endDate - numberOfDaysToServe

--- a/test/retrieve_test.rb
+++ b/test/retrieve_test.rb
@@ -100,24 +100,31 @@ class RetrieveTest < MiniTest::Test
     rsin = rolling_start_interval_number(active_at)
 
     resp = get_date("00000")
-    export = assert_happy_zip_response(resp)
-    keys = [tek(
-      rolling_start_interval_number: rsin,
-      transmission_risk_level: 8,
-      data: "1111111111111111",
-    ), tek(
-      rolling_start_interval_number: rsin,
-      transmission_risk_level: 8,
-      data: "2222222222222222",
-    ), tek(
-      rolling_start_interval_number: rsin,
-      transmission_risk_level: 8,
-      data: "3333333333333333",
-    ), tek(
-      rolling_start_interval_number: rsin,
-      transmission_risk_level: 8,
-      data: "4444444444444444",
-    )]
+
+    config = get_app_config()
+
+    if config["enableEntirePeriodBundle"]
+      export = assert_happy_zip_response(resp)
+      keys = [tek(
+        rolling_start_interval_number: rsin,
+        transmission_risk_level: 8,
+        data: "1111111111111111",
+      ), tek(
+        rolling_start_interval_number: rsin,
+        transmission_risk_level: 8,
+        data: "2222222222222222",
+      ), tek(
+        rolling_start_interval_number: rsin,
+        transmission_risk_level: 8,
+        data: "3333333333333333",
+      ), tek(
+        rolling_start_interval_number: rsin,
+        transmission_risk_level: 8,
+        data: "4444444444444444",
+      )]
+    else
+      assert_response(resp, 410, 'text/plain; charset=utf-8', body: "requested data no longer valid\n")
+    end
   end
 
   def test_period_bounds

--- a/test/retrieve_test.rb
+++ b/test/retrieve_test.rb
@@ -90,12 +90,16 @@ class RetrieveTest < MiniTest::Test
   def test_all_keys
     active_at = time_in_date('10:00', today_utc.prev_day(8))
     two_days_ago = yesterday_utc.prev_day(1)
+    fourteen_days_ago = yesterday_utc.prev_day(13)
+    fiveteen_days_ago = yesterday_utc.prev_day(14)
 
     # Our retrieve endpoint returns keys SUBMITTED within the given period.
-    add_key(active_at: active_at, submitted_at: time_in_date("23:59:59", two_days_ago), data: '1' * 16)
-    add_key(active_at: active_at, submitted_at: time_in_date("00:00", yesterday_utc), data: '2' * 16)
+    add_key(active_at: active_at, submitted_at: time_in_date("23:59:59", fiveteen_days_ago), data: '1' * 16)
+    add_key(active_at: active_at, submitted_at: time_in_date("00:00", fourteen_days_ago), data: '2' * 16)
     add_key(active_at: active_at, submitted_at: time_in_date("01:59:59", yesterday_utc), data: '3' * 16)
     add_key(active_at: active_at, submitted_at: time_in_date("02:00", yesterday_utc), data: '4' * 16)
+    add_key(active_at: active_at, submitted_at: time_in_date("02:00", yesterday_utc), data: '5' * 16)
+    add_key(active_at: active_at, submitted_at: time_in_date("02:00", today_utc), data: '6' * 16)
 
     rsin = rolling_start_interval_number(active_at)
 
@@ -108,10 +112,6 @@ class RetrieveTest < MiniTest::Test
       keys = [tek(
         rolling_start_interval_number: rsin,
         transmission_risk_level: 8,
-        data: "1111111111111111",
-      ), tek(
-        rolling_start_interval_number: rsin,
-        transmission_risk_level: 8,
         data: "2222222222222222",
       ), tek(
         rolling_start_interval_number: rsin,
@@ -121,6 +121,10 @@ class RetrieveTest < MiniTest::Test
         rolling_start_interval_number: rsin,
         transmission_risk_level: 8,
         data: "4444444444444444",
+      ), tek(
+        rolling_start_interval_number: rsin,
+        transmission_risk_level: 8,
+        data: "5555555555555555",
       )]
     else
       assert_response(resp, 410, 'text/plain; charset=utf-8', body: "requested data no longer valid\n")

--- a/test/retrieve_test.rb
+++ b/test/retrieve_test.rb
@@ -87,6 +87,39 @@ class RetrieveTest < MiniTest::Test
     assert_keys(export, keys, region: 'CA', date_number: dn)
   end
 
+  def test_all_keys
+    active_at = time_in_date('10:00', today_utc.prev_day(8))
+    two_days_ago = yesterday_utc.prev_day(1)
+
+    # Our retrieve endpoint returns keys SUBMITTED within the given period.
+    add_key(active_at: active_at, submitted_at: time_in_date("23:59:59", two_days_ago), data: '1' * 16)
+    add_key(active_at: active_at, submitted_at: time_in_date("00:00", yesterday_utc), data: '2' * 16)
+    add_key(active_at: active_at, submitted_at: time_in_date("01:59:59", yesterday_utc), data: '3' * 16)
+    add_key(active_at: active_at, submitted_at: time_in_date("02:00", yesterday_utc), data: '4' * 16)
+
+    rsin = rolling_start_interval_number(active_at)
+
+    resp = get_date("00000")
+    export = assert_happy_zip_response(resp)
+    keys = [tek(
+      rolling_start_interval_number: rsin,
+      transmission_risk_level: 8,
+      data: "1111111111111111",
+    ), tek(
+      rolling_start_interval_number: rsin,
+      transmission_risk_level: 8,
+      data: "2222222222222222",
+    ), tek(
+      rolling_start_interval_number: rsin,
+      transmission_risk_level: 8,
+      data: "3333333333333333",
+    ), tek(
+      rolling_start_interval_number: rsin,
+      transmission_risk_level: 8,
+      data: "4444444444444444",
+    )]
+  end
+
   def test_period_bounds
     active_at = time_in_date('10:00', today_utc.prev_day(8))
     two_days_ago = yesterday_utc.prev_day(1)


### PR DESCRIPTION
This is a feature that will allow a person to download all the key for the period defined by `numberOfDaysToServe`, currently 14, in one package.

The access the feature,` enableEntirePeriodBundle ` needs to be set to `true`. 

Instead of the regular day number since unix time, ex: `18440` we use `00000` because that is not a valid date but does not require the creation of a new API endpoint or changing the authorization logic behind retrieving bundles. The mobile client can use that as a default before replacing it with the current day.