### PR TITLE
configurable IP allow list for /new-key-claim endpoint

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,6 +24,7 @@ env:
   TF_VAR_ecs_task_key_submission_env_key_claim_token: ${{ secrets.TF_VAR_ecs_task_key_submission_env_key_claim_token }}
   TF_VAR_rds_server_db_password: ${{ secrets.TF_VAR_rds_server_db_password }}
   TF_VAR_route53_zone_name: ${{ secrets.TF_VAR_route53_zone_name }}
+  TF_VAR_new_key_claim_allow_list: ${{ secrets.TF_VAR_new_key_claim_allow_list }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -153,3 +153,11 @@ variable "rds_server_instance_class" {
 variable "route53_zone_name" {
   type = string
 }
+
+###
+# AWS WAF - IPs/CIDRs to allow to /new-key-claim
+###
+variable "new_key_claim_allow_list" {
+  type    = list
+  default = ["0.0.0.0/1", "128.0.0.0/1"]
+}

--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -1,4 +1,15 @@
 ###
+# AWS IPSet - list of IPs/CIDRs to allow
+###
+resource "aws_wafv2_ip_set" "new_key_claim" {
+  name               = "new-key-claim"
+  description        = "New Key Claim Allow IPs/CIDRs"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = toset(var.new_key_claim_allow_list)
+}
+
+###
 # AWS WAF - Managed Rules
 ###
 resource "aws_wafv2_web_acl" "key_submission" {
@@ -286,6 +297,11 @@ resource "aws_wafv2_web_acl" "key_submission" {
               priority = 1
               type     = "NONE"
             }
+          }
+        }
+        statement {
+          ip_set_reference_statement {
+            arn = aws_wafv2_ip_set.new_key_claim.arn
           }
         }
       }


### PR DESCRIPTION
ref: #99 

- allows a list of CIDR ranges to be allowed to the `/new-key-claim` endpoint
- TF_VAR_new_key_claim_allow_list secret is required and can be set to `["0.0.0.0/1", "128.0.0.0/1"]` to allow all