### PR TITLE
Convert day bounds to hour bounds

### DIFF
--- a/pkg/persistence/queries.go
+++ b/pkg/persistence/queries.go
@@ -215,9 +215,7 @@ func privForPub(db *sql.DB, pub []byte) *sql.Row {
 // Only return keys that correspond to a Key valid for a date less than 14 days ago.
 //
 // TODO: this might be the right place to pad inappropriately small batches
-func diagnosisKeysForDateNumber(db *sql.DB, region string, dateNumber uint32, currentRollingStartIntervalNumber int32) (*sql.Rows, error) {
-	startHour := dateNumber * 24
-	endHour := startHour + 24
+func diagnosisKeysForHours(db *sql.DB, region string, startHour uint32, endHour uint32, currentRollingStartIntervalNumber int32) (*sql.Rows, error) {
 	minRollingStartIntervalNumber := timemath.RollingStartIntervalNumberPlusDays(currentRollingStartIntervalNumber, -14)
 
 	return db.Query(

--- a/pkg/server/retrieve.go
+++ b/pkg/server/retrieve.go
@@ -71,6 +71,8 @@ func (s *retrieveServlet) retrieve(w http.ResponseWriter, r *http.Request) resul
 	var startTimestamp time.Time
 	var endTimestamp time.Time
 	var dateNumber uint32
+	var startHour uint32
+	var endHour uint32
 
 	if config.AppConstants.EnableEntirePeriodBundle == true && vars["day"] == "00000" {
 
@@ -82,6 +84,9 @@ func (s *retrieveServlet) retrieve(w http.ResponseWriter, r *http.Request) resul
 		startTimestamp = time.Unix(int64(startDate*86400), 0)
 		endTimestamp = time.Unix(int64((endDate+1)*86400), 0)
 
+		startHour = startDate * 24
+		endHour = (endDate * 24) + 24
+
 	} else {
 
 		dateNumber64, err := strconv.ParseUint(vars["day"], 10, 32)
@@ -92,6 +97,9 @@ func (s *retrieveServlet) retrieve(w http.ResponseWriter, r *http.Request) resul
 
 		startTimestamp = time.Unix(int64(dateNumber*86400), 0)
 		endTimestamp = time.Unix(int64((dateNumber+1)*86400), 0)
+
+		startHour = dateNumber * 24
+		endHour = startHour + 24
 
 	}
 
@@ -108,7 +116,7 @@ func (s *retrieveServlet) retrieve(w http.ResponseWriter, r *http.Request) resul
 
 	// TODO: Maybe implement multi-pack linked-list scheme depending on what we hear back from G/A
 
-	keys, err := s.db.FetchKeysForDateNumber(region, dateNumber, currentRSIN)
+	keys, err := s.db.FetchKeysForHours(region, startHour, endHour, currentRSIN)
 	if err != nil {
 		return s.fail(log(ctx, err), w, "database error", "", http.StatusInternalServerError)
 	}

--- a/test/retrieve_test.rb
+++ b/test/retrieve_test.rb
@@ -90,8 +90,8 @@ class RetrieveTest < MiniTest::Test
   def test_all_keys
     active_at = time_in_date('10:00', today_utc.prev_day(8))
     two_days_ago = yesterday_utc.prev_day(1)
-    fourteen_days_ago = yesterday_utc.prev_day(13)
-    fiveteen_days_ago = yesterday_utc.prev_day(14)
+    fourteen_days_ago = yesterday_utc.prev_day(14)
+    fiveteen_days_ago = yesterday_utc.prev_day(15)
 
     # Our retrieve endpoint returns keys SUBMITTED within the given period.
     add_key(active_at: active_at, submitted_at: time_in_date("23:59:59", fiveteen_days_ago), data: '1' * 16)
@@ -126,6 +126,7 @@ class RetrieveTest < MiniTest::Test
         transmission_risk_level: 8,
         data: "5555555555555555",
       )]
+      assert_equal(keys, export.keys)
     else
       assert_response(resp, 410, 'text/plain; charset=utf-8', body: "requested data no longer valid\n")
     end
@@ -155,7 +156,12 @@ class RetrieveTest < MiniTest::Test
       rolling_start_interval_number: rsin,
       transmission_risk_level: 8,
       data: "3333333333333333",
+    ), tek(
+      rolling_start_interval_number: rsin,
+      transmission_risk_level: 8,
+      data: "4444444444444444",
     )]
+    assert_equal(keys, export.keys)
   end
 
   def test_invalid_auth


### PR DESCRIPTION
Fixes logic in #176. When I implemented the logic I relied on the Ruby test to pass. Unfortunately the Ruby logic never called an assert. I have fixed the test and simplified the logic so you can pass it startHour and endHour need to be explicitly set before it gets passed to the query function.