### PR TITLE
enable wafv2 logging

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -25,6 +25,7 @@ env:
   TF_VAR_rds_server_db_password: ${{ secrets.TF_VAR_rds_server_db_password }}
   TF_VAR_route53_zone_name: ${{ secrets.TF_VAR_route53_zone_name }}
   TF_VAR_new_key_claim_allow_list: ${{ secrets.TF_VAR_new_key_claim_allow_list }}
+  TF_VAR_environment: ${{ secrets.TF_VAR_environment }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/config/terraform/aws/kinesis.tf
+++ b/config/terraform/aws/kinesis.tf
@@ -1,0 +1,74 @@
+###
+# AWS Kinesis Firehose - IAM Role
+###
+resource "aws_iam_role" "firehose_waf_logs" {
+  name = "firehose_waf_logs"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "firehose.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+###
+# AWS Kinesis Firehose - IAM Policy
+###
+resource "aws_iam_role_policy" "firehose_waf_logs" {
+  name   = "firehose-waf-logs-policy"
+  role   = aws_iam_role.firehose_waf_logs.id
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.firehose_waf_logs.arn}",
+        "${aws_s3_bucket.firehose_waf_logs.arn}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iam:CreateServiceLinkedRole",
+      "Resource": "arn:aws:iam::*:role/aws-service-role/wafv2.amazonaws.com/AWSServiceRoleForWAFV2Logging"
+    }
+  ]
+}
+EOF
+}
+
+###
+# AWS Kinesis Firehose - Delivery Stream
+###
+resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs" {
+  name        = "aws-waf-logs-covid-shield"
+  destination = "s3"
+  server_side_encryption {
+    enabled = true
+  }
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose_waf_logs.arn
+    bucket_arn = aws_s3_bucket.firehose_waf_logs.arn
+  }
+}

--- a/config/terraform/aws/s3.tf
+++ b/config/terraform/aws/s3.tf
@@ -1,0 +1,34 @@
+###
+# AWS S3 bucket - S3 bucket access logs
+###
+resource "aws_s3_bucket" "s3_access_logs" {
+  bucket = "covid-shield-${var.environment}-s3-access-logs"
+  acl    = "log-delivery-write"
+  #tfsec:ignore:AWS002
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+###
+# AWS S3 bucket - WAF log target
+###
+resource "aws_s3_bucket" "firehose_waf_logs" {
+  bucket = "covid-shield-${var.environment}-waf-logs"
+  acl    = "private"
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+  logging {
+    target_bucket = aws_s3_bucket.s3_access_logs.id
+    target_prefix = "waf/"
+  }
+}

--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -13,6 +13,10 @@ variable "billing_tag_value" {
   type = string
 }
 
+variable "environment" {
+  type = string
+}
+
 ###
 # AWS Cloud Watch - cloudwatch.tf
 ###

--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -332,3 +332,16 @@ resource "aws_wafv2_web_acl_association" "key_submission_assocation" {
   resource_arn = aws_lb.covidshield_key_submission.arn
   web_acl_arn  = aws_wafv2_web_acl.key_submission.arn
 }
+
+###
+# AWS WAF - Logging
+###
+resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs" {
+  log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn}"]
+  resource_arn            = aws_wafv2_web_acl.key_submission.arn
+  redacted_fields {
+    single_header {
+      name = "authorization"
+    }
+  }
+}


### PR DESCRIPTION
-requires TF_VAR_environment to create a unique s3 bucket
- enables wafv2 logging, creates kinesis firehose delivery stream, and target s3 bucket
- redacts "authorization" header