### PR TITLE
use priceclass 100 for Cloudfront CDN

### DIFF
--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -41,6 +41,8 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
     compress               = true
   }
 
+  price_class = "PriceClass_100"
+
   restrictions {
     geo_restriction {
       restriction_type = "none"


### PR DESCRIPTION
Use Cloudfront CDN Price Class 100 as per https://aws.amazon.com/cloudfront/pricing/