### PR TITLE
set taskdef image to repo name without sha to avoid plan changes

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -52,9 +52,8 @@ jobs:
         run: terraform fmt -check
 
       - name: Terraform Plan
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TF_VAR_github_sha: ${{ github.sha }}
+        # env:
+          # TF_VAR_github_sha: ${{ github.sha }}
         run: terraform plan
 
   terraform-security-scan:
@@ -93,15 +92,13 @@ jobs:
           -backend-config="region=ca-central-1"
 
     - name: Terraform Plan
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TF_VAR_github_sha: ${{ github.sha }}
+      # env:
+        # TF_VAR_github_sha: ${{ github.sha }}
       run: terraform plan -out terraform.tfplan
 
     - name: Terraform Apply
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TF_VAR_github_sha: ${{ github.sha }}
+      # env:
+        # TF_VAR_github_sha: ${{ github.sha }}
       run: terraform apply -auto-approve terraform.tfplan
 
     - name: Check For New Deployments

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -52,8 +52,6 @@ jobs:
         run: terraform fmt -check
 
       - name: Terraform Plan
-        # env:
-          # TF_VAR_github_sha: ${{ github.sha }}
         run: terraform plan
 
   terraform-security-scan:
@@ -92,13 +90,9 @@ jobs:
           -backend-config="region=ca-central-1"
 
     - name: Terraform Plan
-      # env:
-        # TF_VAR_github_sha: ${{ github.sha }}
       run: terraform plan -out terraform.tfplan
 
     - name: Terraform Apply
-      # env:
-        # TF_VAR_github_sha: ${{ github.sha }}
       run: terraform apply -auto-approve terraform.tfplan
 
     - name: Check For New Deployments

--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -30,7 +30,7 @@ data "template_file" "covidshield_key_retrieval_task" {
   template = file("task-definitions/covidshield_key_retrieval.json")
 
   vars = {
-    image                 = "${local.retrieval_repo}:${var.github_sha}"
+    image                 = "${local.retrieval_repo}"
     awslogs-group         = aws_cloudwatch_log_group.covidshield.name
     awslogs-region        = var.region
     awslogs-stream-prefix = "ecs-${var.ecs_key_retrieval_name}"
@@ -163,7 +163,7 @@ data "template_file" "covidshield_key_submission_task" {
   template = file("task-definitions/covidshield_key_submission.json")
 
   vars = {
-    image                 = "${local.submission_repo}:${var.github_sha}"
+    image                 = "${local.submission_repo}"
     awslogs-group         = aws_cloudwatch_log_group.covidshield.name
     awslogs-region        = var.region
     awslogs-stream-prefix = "ecs-${var.ecs_key_submission_name}"

--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -44,18 +44,22 @@ variable "scale_out_cooldown" {
   type    = number
   default = 60
 }
+
 variable "cpu_scale_metric" {
   type    = number
   default = 60
 }
+
 variable "memory_scale_metric" {
   type    = number
   default = 60
 }
+
 variable "min_capacity" {
   type    = number
   default = 2
 }
+
 variable "max_capacity" {
   type    = number
   default = 10


### PR DESCRIPTION
By removing the git sha tag from the task definition image reference, terraform will stop trying to change the task definition on every commit.