### PR TITLE
Changes for AWS Shield

### DIFF
--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -17,6 +17,7 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
 
   enabled         = true
   is_ipv6_enabled = true
+  web_acl_id      = aws_wafv2_web_acl.key_retrieval_cdn.arn
 
   aliases = ["retrieval.${var.route53_zone_name}"]
 

--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -249,3 +249,43 @@ resource "aws_cloudwatch_metric_alarm" "fatal_logged_warn" {
 
   alarm_actions = [aws_sns_topic.alert_warning.arn, aws_sns_topic.alert_critical.arn]
 }
+
+###
+# AWS CloudWatch Metrics - DDoS Alarms
+###
+
+resource "aws_cloudwatch_metric_alarm" "ddos_detected_submission" {
+  alarm_name          = "DDoSDetectedSubmissionALB"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDoSProtection"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+  alarm_description   = "This metric monitors for DDoS detected"
+
+  alarm_actions = [aws_sns_topic.alert_warning.arn, aws_sns_topic.alert_critical.arn]
+
+  dimensions = {
+    ResourceArn = aws_lb.covidshield_key_submission.arn
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ddos_detected_retrieval" {
+  alarm_name          = "DDoSDetectedRetrievalALB"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDoSProtection"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+  alarm_description   = "This metric monitors for DDoS detected"
+
+  alarm_actions = [aws_sns_topic.alert_warning.arn, aws_sns_topic.alert_critical.arn]
+
+  dimensions = {
+    ResourceArn = aws_lb.covidshield_key_retrieval.arn
+  }
+}

--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -263,7 +263,7 @@ resource "aws_cloudwatch_metric_alarm" "ddos_detected_submission" {
   period              = "60"
   statistic           = "Sum"
   threshold           = "1"
-  alarm_description   = "This metric monitors for DDoS detected"
+  alarm_description   = "This metric monitors for DDoS detected on submission ALB"
 
   alarm_actions = [aws_sns_topic.alert_warning.arn, aws_sns_topic.alert_critical.arn]
 
@@ -281,7 +281,7 @@ resource "aws_cloudwatch_metric_alarm" "ddos_detected_retrieval" {
   period              = "60"
   statistic           = "Sum"
   threshold           = "1"
-  alarm_description   = "This metric monitors for DDoS detected"
+  alarm_description   = "This metric monitors for DDoS detected on retrieval ALB"
 
   alarm_actions = [aws_sns_topic.alert_warning.arn, aws_sns_topic.alert_critical.arn]
 

--- a/config/terraform/aws/kinesis.tf
+++ b/config/terraform/aws/kinesis.tf
@@ -72,3 +72,18 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs" {
     bucket_arn = aws_s3_bucket.firehose_waf_logs.arn
   }
 }
+
+resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs_us_east" {
+  provider = aws.us-east-1
+
+  name        = "aws-waf-logs-covid-shield-us-east"
+  destination = "s3"
+  server_side_encryption {
+    enabled = true
+  }
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose_waf_logs.arn
+    bucket_arn = aws_s3_bucket.firehose_waf_logs.arn
+  }
+}

--- a/config/terraform/aws/route53.tf
+++ b/config/terraform/aws/route53.tf
@@ -30,7 +30,7 @@ resource "aws_route53_health_check" "covidshield_key_retrieval_healthcheck" {
   fqdn              = "retrieval.${aws_route53_zone.covidshield.name}"
   port              = 443
   type              = "HTTPS"
-  resource_path     = "services/ping"
+  resource_path     = "/services/ping"
   failure_threshold = "3"
   request_interval  = "30"
 
@@ -59,7 +59,7 @@ resource "aws_route53_health_check" "covidshield_key_submission_healthcheck" {
   fqdn              = "submission.${aws_route53_zone.covidshield.name}"
   port              = 443
   type              = "HTTPS"
-  resource_path     = "services/ping"
+  resource_path     = "/services/ping"
   failure_threshold = "3"
   request_interval  = "30"
 

--- a/config/terraform/aws/route53.tf
+++ b/config/terraform/aws/route53.tf
@@ -27,7 +27,7 @@ resource "aws_route53_record" "covidshield_key_retrieval" {
 }
 
 resource "aws_route53_health_check" "covidshield_key_retrieval_healthcheck" {
-  fqdn              = "retrieval.${aws_route53_zone.covidshield.name}"
+  fqdn              = "retrieval.${var.route53_zone_name}"
   port              = 443
   type              = "HTTPS"
   resource_path     = "/services/ping"
@@ -56,7 +56,7 @@ resource "aws_route53_record" "covidshield_key_submission" {
 }
 
 resource "aws_route53_health_check" "covidshield_key_submission_healthcheck" {
-  fqdn              = "submission.${aws_route53_zone.covidshield.name}"
+  fqdn              = "submission.${var.route53_zone_name}"
   port              = 443
   type              = "HTTPS"
   resource_path     = "/services/ping"

--- a/config/terraform/aws/route53.tf
+++ b/config/terraform/aws/route53.tf
@@ -26,6 +26,19 @@ resource "aws_route53_record" "covidshield_key_retrieval" {
   }
 }
 
+resource "aws_route53_health_check" "covidshield_key_retrieval_healthcheck" {
+  fqdn              = "retrieval.${aws_route53_zone.covidshield.name}"
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "services/ping"
+  failure_threshold = "3"
+  request_interval  = "30"
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}
+
 ###
 # Route53 Record - Key Submission
 ###
@@ -39,5 +52,18 @@ resource "aws_route53_record" "covidshield_key_submission" {
     name                   = aws_lb.covidshield_key_submission.dns_name
     zone_id                = aws_lb.covidshield_key_submission.zone_id
     evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_health_check" "covidshield_key_submission_healthcheck" {
+  fqdn              = "submission.${aws_route53_zone.covidshield.name}"
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "services/ping"
+  failure_threshold = "3"
+  request_interval  = "30"
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
   }
 }

--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -395,8 +395,3 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_retrieval"
   log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn}"]
   resource_arn            = aws_wafv2_web_acl.key_retrieval.arn
 }
-
-resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_retrieval_cdn" {
-  log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn}"]
-  resource_arn            = aws_wafv2_web_acl.key_retrieval_cdn.arn
-}

--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -395,3 +395,10 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_retrieval"
   log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn}"]
   resource_arn            = aws_wafv2_web_acl.key_retrieval.arn
 }
+
+resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_retrieval_cdn" {
+  provider = aws.us-east-1
+
+  log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs_us_east.arn}"]
+  resource_arn            = aws_wafv2_web_acl.key_retrieval_cdn.arn
+}

--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -332,6 +332,16 @@ resource "aws_wafv2_web_acl" "key_retrieval" {
   default_action {
     allow {}
   }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "key_retrieval"
+    sampled_requests_enabled   = false
+  }
 }
 
 resource "aws_wafv2_web_acl" "key_retrieval_cdn" {
@@ -342,6 +352,16 @@ resource "aws_wafv2_web_acl" "key_retrieval_cdn" {
 
   default_action {
     allow {}
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "key_retrieval_cdn"
+    sampled_requests_enabled   = false
   }
 }
 

--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -325,12 +325,44 @@ resource "aws_wafv2_web_acl" "key_submission" {
   }
 }
 
+resource "aws_wafv2_web_acl" "key_retrieval" {
+  name  = "key_retrieval"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+}
+
+resource "aws_wafv2_web_acl" "key_retrieval_cdn" {
+  provider = aws.us-east-1
+
+  name  = "key_retrieval_cdn"
+  scope = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+}
+
 ###
 # AWS WAF - Resource Assocation
 ###
 resource "aws_wafv2_web_acl_association" "key_submission_assocation" {
   resource_arn = aws_lb.covidshield_key_submission.arn
   web_acl_arn  = aws_wafv2_web_acl.key_submission.arn
+}
+
+resource "aws_wafv2_web_acl_association" "key_retrieval_assocation" {
+  resource_arn = aws_lb.covidshield_key_retrieval.arn
+  web_acl_arn  = aws_wafv2_web_acl.key_retrieval.arn
+}
+
+resource "aws_wafv2_web_acl_association" "key_retrieval_cdn_assocation" {
+  provider = aws.us-east-1
+
+  resource_arn = aws_cloudfront_distribution.key_retrieval_distribution.arn
+  web_acl_arn  = aws_wafv2_web_acl.key_retrieval_cdn.arn
 }
 
 ###
@@ -344,4 +376,14 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs" {
       name = "authorization"
     }
   }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_retrieval" {
+  log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn}"]
+  resource_arn            = aws_wafv2_web_acl.key_retrieval.arn
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_retrieval_cdn" {
+  log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn}"]
+  resource_arn            = aws_wafv2_web_acl.key_retrieval_cdn.arn
 }

--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -378,13 +378,6 @@ resource "aws_wafv2_web_acl_association" "key_retrieval_assocation" {
   web_acl_arn  = aws_wafv2_web_acl.key_retrieval.arn
 }
 
-resource "aws_wafv2_web_acl_association" "key_retrieval_cdn_assocation" {
-  provider = aws.us-east-1
-
-  resource_arn = aws_cloudfront_distribution.key_retrieval_distribution.arn
-  web_acl_arn  = aws_wafv2_web_acl.key_retrieval_cdn.arn
-}
-
 ###
 # AWS WAF - Logging
 ###


### PR DESCRIPTION
- Adds alarms for when the DDoS alerts are triggered on both the submission and retrieval ALB.
- Adds additional Route53 health checks that can be used by the DDoS team
- Adds allow all WAFs for retrieval ALB and retrieval CDN to capture logs

Closes #71 and Closes #89 