### PR TITLE
Extend One Time Code Keyspace

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,6 @@ defaultSubmissionServerPort: 8000
 defaultRetrievalServerPort: 8001
 defaultServerPort: 8010
 workerExpirationInterval: 30
-maxOneTimeCode: 1e8
 maxConsecutiveClaimKeyFailures: 8
 claimKeyBanDuration: 1
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,7 +14,6 @@ type Constants struct {
 	DefaultRetrievalServerPort         uint32
 	DefaultServerPort                  uint32
 	WorkerExpirationInterval           uint32
-	MaxOneTimeCode                     int64
 	MaxConsecutiveClaimKeyFailures     int
 	ClaimKeyBanDuration                uint32
 	MaxDiagnosisKeyRetentionDays       uint32
@@ -52,7 +51,6 @@ func setDefaults() {
 	viper.SetDefault("defaultRetrievalServerPort", 8001)
 	viper.SetDefault("defaultServerPort", 8010)
 	viper.SetDefault("workerExpirationInterval", 30)
-	viper.SetDefault("maxOneTimeCode", 1e8)
 	viper.SetDefault("maxConsecutiveClaimKeyFailures", 8)
 	viper.SetDefault("claimKeyBanDuration", 1)
 	viper.SetDefault("maxDiagnosisKeyRetentionDays", 15)

--- a/pkg/persistence/db.go
+++ b/pkg/persistence/db.go
@@ -173,18 +173,34 @@ func (c *conn) NewKeyClaim(region, originator, hashID string) (string, error) {
 	return "", err
 }
 
+// Generate a random one time code in the format AAABBBCCCC where
+// each group is made up of a character set. For each group it first
+// randomizes which charater set to use. Then passes that character
+// set and the desired length in another function to generate the
+// string for that group.
 func generateOneTimeCode() (string, error) {
-	charsets := [2][]rune{[]rune("AEFHJKLQRSUWXYZ"), []rune("2456789")}
+	characterSets := [2][]rune{
+		[]rune("AEFHJKLQRSUWXYZ"),
+		[]rune("2456789"),
+	}
 
-	seg1, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charsets))))
-	seg2, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charsets))))
-	seg3, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charsets))))
+	characterSetLength := int64(len(characterSets))
 
-	oneTimeCode := genRandom(charsets[seg1.Int64()], 3) + genRandom(charsets[seg2.Int64()], 3) + genRandom(charsets[seg3.Int64()], 4)
+	seg1, err := rand.Int(rand.Reader, big.NewInt(characterSetLength))
+	seg2, err := rand.Int(rand.Reader, big.NewInt(characterSetLength))
+	seg3, err := rand.Int(rand.Reader, big.NewInt(characterSetLength))
 
-	return oneTimeCode, nil
+	oneTimeCode := genRandom(characterSets[seg1.Int64()], 3) +
+		genRandom(characterSets[seg2.Int64()], 3) +
+		genRandom(characterSets[seg3.Int64()], 4)
+
+	return oneTimeCode, err
 }
 
+// Generates a string of random characters based on a
+// passed list of characters and a desired length. For each
+// position in the desired length, generates a random number
+// between 0 and the length of the character set.
 func genRandom(chars []rune, length int64) string {
 	var b strings.Builder
 	for i := int64(0); i < length; i++ {

--- a/pkg/persistence/db.go
+++ b/pkg/persistence/db.go
@@ -143,8 +143,6 @@ func (c *conn) ClaimKey(oneTimeCode string, appPublicKey []byte) ([]byte, error)
 // HashID that has already used the code
 var ErrHashIDClaimed = errors.New("HashID claimed")
 
-const maxOneTimeCode = 1e8
-
 func (c *conn) NewKeyClaim(region, originator, hashID string) (string, error) {
 	var err error
 

--- a/pkg/persistence/db.go
+++ b/pkg/persistence/db.go
@@ -178,12 +178,11 @@ func (c *conn) NewKeyClaim(region, originator, hashID string) (string, error) {
 func generateOneTimeCode() (string, error) {
 	charsets := [2][]rune{[]rune("AEFHJKLQRSUWXYZ"), []rune("2456789")}
 
-	//seg1, err := rand.Int(rand.Reader, big.NewInt(int64(len(charsets))))
-	//seg2, err := rand.Int(rand.Reader, big.NewInt(int64(len(charsets))))
-	//seg3, err := rand.Int(rand.Reader, big.NewInt(int64(len(charsets))))
+	seg1, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charsets))))
+	seg2, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charsets))))
+	seg3, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charsets))))
 
-	//oneTimeCode := genRandom(charsets[seg1.Int64()], 3) + genRandom(charsets[seg2.Int64()], 3) + genRandom(charsets[seg3.Int64()], 4)
-	oneTimeCode := genRandom(append(charsets[0], charsets[1]...), 1)
+	oneTimeCode := genRandom(charsets[seg1.Int64()], 3) + genRandom(charsets[seg2.Int64()], 3) + genRandom(charsets[seg3.Int64()], 4)
 
 	return oneTimeCode, nil
 }

--- a/pkg/persistence/db.go
+++ b/pkg/persistence/db.go
@@ -183,7 +183,7 @@ func generateOneTimeCode() (string, error) {
 	//seg3, err := rand.Int(rand.Reader, big.NewInt(int64(len(charsets))))
 
 	//oneTimeCode := genRandom(charsets[seg1.Int64()], 3) + genRandom(charsets[seg2.Int64()], 3) + genRandom(charsets[seg3.Int64()], 4)
-	oneTimeCode := genRandom(append(charsets[0], charsets[1]...), 10)
+	oneTimeCode := genRandom(append(charsets[0], charsets[1]...), 1)
 
 	return oneTimeCode, nil
 }

--- a/pkg/persistence/migrator.go
+++ b/pkg/persistence/migrator.go
@@ -79,6 +79,11 @@ CREATE TABLE IF NOT EXISTS failed_key_claim_attempts (
 			`ALTER TABLE encryption_keys ADD COLUMN hash_id VARCHAR(128)`,
 			`ALTER TABLE encryption_keys ADD INDEX (hash_id)`,
 		},
+	}, {
+		id: "5",
+		statements: []string{
+			`ALTER TABLE encryption_keys MODIFY one_time_code VARCHAR(10)`,
+		},
 	},
 }
 

--- a/pkg/server/keyclaim.go
+++ b/pkg/server/keyclaim.go
@@ -137,6 +137,11 @@ func (s *keyClaimServlet) claimKey(w http.ResponseWriter, r *http.Request) resul
 	}
 
 	oneTimeCode := req.GetOneTimeCode()
+	
+	// Handle odd app inputs
+	oneTimeCode = strings.ReplaceAll(oneTimeCode, " ", "")
+	oneTimeCode = strings.ReplaceAll(oneTimeCode, "-", "")
+
 	appPublicKey := req.GetAppPublicKey()
 
 	serverPub, err := s.db.ClaimKey(oneTimeCode, appPublicKey)

--- a/scripts/create-upload-payload-for-load-testing
+++ b/scripts/create-upload-payload-for-load-testing
@@ -75,7 +75,7 @@ module CreateUploadPayloadForLoadTesting
     when String
       assert_equal(body, resp.body)
     when Regexp
-      assert_match(/\A[0-9]{8}\n\z/m, resp.body)
+      assert_match(/\A[A-Z0-9]{10}\n\z/m, resp.body)
     end
   end
 

--- a/test/claim_key_test.rb
+++ b/test/claim_key_test.rb
@@ -69,6 +69,32 @@ class ClaimKeyTest < MiniTest::Test
       assert_equal(8, kcr.tries_remaining)
     end
 
+    # Try code with spaces
+    code_with_spaces = new_valid_one_time_code.insert(3, " ").insert(6, " ")
+    kcq = Covidshield::KeyClaimRequest.new(
+      one_time_code: code_with_spaces,
+      app_public_key: "00001111222233334444555566667706"
+    )
+    resp = @sub_conn.post('/claim-key', kcq.to_proto)
+    assert_response(resp, 200, 'application/x-protobuf')
+    kcr = Covidshield::KeyClaimResponse.decode(resp.body)
+    assert_equal(:NONE, kcr.error)
+    assert_equal(32, kcr.server_public_key.each_byte.size)
+    assert_equal(8, kcr.tries_remaining)
+
+    # Try code with dashes
+    code_with_dashes = new_valid_one_time_code.insert(3, "-").insert(6, "-")
+    kcq = Covidshield::KeyClaimRequest.new(
+      one_time_code: code_with_dashes,
+      app_public_key: "00001111222233334444555566667707"
+    )
+    resp = @sub_conn.post('/claim-key', kcq.to_proto)
+    assert_response(resp, 200, 'application/x-protobuf')
+    kcr = Covidshield::KeyClaimResponse.decode(resp.body)
+    assert_equal(:NONE, kcr.error)
+    assert_equal(32, kcr.server_public_key.each_byte.size)
+    assert_equal(8, kcr.tries_remaining)
+
     # app_public_key already exists
     kcq = Covidshield::KeyClaimRequest.new(
       one_time_code: new_valid_one_time_code,

--- a/test/claim_key_test.rb
+++ b/test/claim_key_test.rb
@@ -83,7 +83,7 @@ class ClaimKeyTest < MiniTest::Test
     kcr = Covidshield::KeyClaimResponse.decode(resp.body)
     assert_equal(:NONE, kcr.error)
     assert_equal(32, kcr.server_public_key.each_byte.size)
-    assert_equal(8, kcr.tries_remaining)
+    assert_equal(maxConsecutiveClaimKeyFailures, kcr.tries_remaining)
 
     # Try code with dashes
     code_with_dashes = new_valid_one_time_code.insert(3, "-").insert(6, "-")
@@ -96,7 +96,7 @@ class ClaimKeyTest < MiniTest::Test
     kcr = Covidshield::KeyClaimResponse.decode(resp.body)
     assert_equal(:NONE, kcr.error)
     assert_equal(32, kcr.server_public_key.each_byte.size)
-    assert_equal(8, kcr.tries_remaining)
+    assert_equal(maxConsecutiveClaimKeyFailures, kcr.tries_remaining)
 
     # app_public_key already exists
     kcq = Covidshield::KeyClaimRequest.new(

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -156,7 +156,7 @@ module Helper
       when String
         assert_equal(body, resp.body)
       when Regexp
-        assert_match(/\A[0-9]{8}\n\z/m, resp.body)
+        assert_match(/\A[A-Z0-9]{10}\n\z/m, resp.body)
       end
     end
 

--- a/test/new_key_claim_hash_id_test.rb
+++ b/test/new_key_claim_hash_id_test.rb
@@ -24,7 +24,7 @@ class NewKeyClaimhashIDTest < MiniTest::Test
       req.url("/new-key-claim/#{hash_id}")
       req.headers['Authorization'] = 'Bearer second-very-long-token'
     end
-    assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
+    assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[A-Z0-9]{10}\n\z/m)
     previous_code = resp.body
 
     # Returns another code if hashID not claimed
@@ -32,7 +32,7 @@ class NewKeyClaimhashIDTest < MiniTest::Test
       req.url("/new-key-claim/#{hash_id}")
       req.headers['Authorization'] = 'Bearer second-very-long-token'
     end
-    assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
+    assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[A-Z0-9]{10}\n\z/m)
     refute_equal(previous_code, resp.body)
     valid_code = resp.body
 

--- a/test/new_key_claim_test.rb
+++ b/test/new_key_claim_test.rb
@@ -19,14 +19,14 @@ class NewKeyClaimTest < MiniTest::Test
       req.url('/new-key-claim')
       req.headers['Authorization'] = 'Bearer first-very-long-token'
     end
-    assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
+    assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[A-Z0-9]{10}\n\z/m)
     assert_equal(['first-very-long-token'], encryption_originators)
 
     resp = @sub_conn.post do |req|
       req.url('/new-key-claim')
       req.headers['Authorization'] = 'Bearer second-very-long-token'
     end
-    assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
+    assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[A-Z0-9]{10}\n\z/m)
     assert_equal(['first-very-long-token', 'second-very-long-token'], encryption_originators)
 
     %w[get patch delete put].each do |meth|


### PR DESCRIPTION
This pull request extends the one time code key space from 8 numeric digits to a 10 alphanumeric key space with 22 characters. The format of the new code is three groups (A,B, and C) in the following format: AAABBBCCCC. Each group an either container letters or numbers, but not both. Example codes are:

```
296JYYQRWE
669YES8644
ZLE9859958
446657ZWKH
628977WUYZ
EXQ699AQAW
EYH299YLER
795YHFSYLH
EAS8757467
642788EJQA
```