### PR TITLE
Adds more alerts for metrics

### DIFF
--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -374,7 +374,7 @@ resource "aws_cloudwatch_metric_alarm" "ddos_detected_cdn" {
   threshold           = "1"
   alarm_description   = "This metric monitors for DDoS detected on retrieval CDN"
 
-  alarm_actions = [aws_sns_topic.alert_warning.arn, aws_sns_topic.alert_critical.arn]
+  alarm_actions = [aws_sns_topic.alert_warning_us_east.arn, aws_sns_topic.alert_critical_us_east.arn]
 
   dimensions = {
     ResourceArn = aws_cloudfront_distribution.key_retrieval_distribution.arn
@@ -394,7 +394,7 @@ resource "aws_cloudwatch_metric_alarm" "ddos_detected_route53" {
   threshold           = "1"
   alarm_description   = "This metric monitors for DDoS detected on route 53"
 
-  alarm_actions = [aws_sns_topic.alert_warning.arn, aws_sns_topic.alert_critical.arn]
+  alarm_actions = [aws_sns_topic.alert_warning.arn_us_east, aws_sns_topic.alert_critical_us_east.arn]
 
   dimensions = {
     ResourceArn = "arn:aws:route53:::hostedzone/${aws_route53_zone.covidshield.zone_id}"
@@ -406,6 +406,7 @@ resource "aws_cloudwatch_metric_alarm" "ddos_detected_route53" {
 ###
 
 resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
+  provider = aws.us-east-1
 
   alarm_name          = "Route53RetrievalHealthCheck"
   alarm_description   = "Check that the Retrieval server is in alarm"
@@ -418,7 +419,7 @@ resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
   threshold           = "1"
   treat_missing_data  = "breaching"
 
-  alarm_actions = [aws_sns_topic.alert_warning.arn, aws_sns_topic.alert_critical.arn]
+  alarm_actions = [aws_sns_topic.alert_warning_us_east.arn, aws_sns_topic.alert_critical_us_east.arn]
 
   dimensions = {
     HealthCheckId = aws_route53_health_check.covidshield_key_retrieval_healthcheck.id
@@ -426,6 +427,7 @@ resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "route53_submission_health_check" {
+  provider = aws.us-east-1
 
   alarm_name          = "Route53SubmissionHealthCheck"
   alarm_description   = "Check that the Submission server is in alarm"
@@ -438,7 +440,7 @@ resource "aws_cloudwatch_metric_alarm" "route53_submission_health_check" {
   threshold           = "1"
   treat_missing_data  = "breaching"
 
-  alarm_actions = [aws_sns_topic.alert_warning.arn, aws_sns_topic.alert_critical.arn]
+  alarm_actions = [aws_sns_topic.alert_warning_us_east.arn, aws_sns_topic.alert_critical_us_east.arn]
 
   dimensions = {
     HealthCheckId = aws_route53_health_check.covidshield_key_submission_healthcheck.id

--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -394,7 +394,7 @@ resource "aws_cloudwatch_metric_alarm" "ddos_detected_route53" {
   threshold           = "1"
   alarm_description   = "This metric monitors for DDoS detected on route 53"
 
-  alarm_actions = [aws_sns_topic.alert_warning.arn_us_east, aws_sns_topic.alert_critical_us_east.arn]
+  alarm_actions = [aws_sns_topic.alert_warning_us_east.arn, aws_sns_topic.alert_critical_us_east.arn]
 
   dimensions = {
     ResourceArn = "arn:aws:route53:::hostedzone/${aws_route53_zone.covidshield.zone_id}"

--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -117,6 +117,20 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_new_one_time_code_requests_
   alarm_actions = [aws_sns_topic.alert_warning.arn]
 }
 
+resource "aws_cloudwatch_metric_alarm" "unauthorized_new_one_time_code_requests_critical" {
+  alarm_name          = "UnauthorizedNewOneTimeCodeRequestsCritical"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.unauthorized_new_one_time_code_requests.name
+  namespace           = "CovidShield"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "100"
+  alarm_description   = "This metric monitors the 401 response rate for /new-key-claim"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
+}
+
 resource "aws_cloudwatch_log_metric_filter" "unauthorized_one_time_code_claim_requests" {
   name           = "UnauthorizedOneTimeCodeClaimRequests"
   pattern        = "statusCode=401 msg=\"http response\" \"path=/claim-key\""
@@ -143,6 +157,20 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_one_time_code_claim_request
   alarm_actions = [aws_sns_topic.alert_warning.arn]
 }
 
+resource "aws_cloudwatch_metric_alarm" "unauthorized_one_time_code_claim_requests_critical" {
+  alarm_name          = "UnauthorizedOneTimeCodeClaimRequestsCritical"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.unauthorized_one_time_code_claim_requests.name
+  namespace           = "CovidShield"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "100"
+  alarm_description   = "This metric monitors the 401 response rate for /claim-key"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
+}
+
 resource "aws_cloudwatch_log_metric_filter" "unauthorized_upload_requests" {
   name           = "UnauthorizedUploadRequests"
   pattern        = "statusClass=4xx msg=\"http response\" \"path=/upload\""
@@ -167,6 +195,20 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_upload_requests_warn" {
   alarm_description   = "This metric monitors the 4xx response rate for /upload"
 
   alarm_actions = [aws_sns_topic.alert_warning.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "unauthorized_upload_requests_critical" {
+  alarm_name          = "UnauthorizedUploadRequestsCritical"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.unauthorized_upload_requests.name
+  namespace           = "CovidShield"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "100"
+  alarm_description   = "This metric monitors the 4xx response rate for /upload"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
 }
 
 ###
@@ -199,6 +241,20 @@ resource "aws_cloudwatch_metric_alarm" "five_hundred_response_warn" {
   alarm_actions = [aws_sns_topic.alert_warning.arn]
 }
 
+resource "aws_cloudwatch_metric_alarm" "five_hundred_response_critical" {
+  alarm_name          = "500ResponseCritical"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.five_hundred_response.name
+  namespace           = "CovidShield"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "10"
+  alarm_description   = "This metric monitors for an 5xx level response"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
+}
+
 resource "aws_cloudwatch_log_metric_filter" "error_logged" {
   name           = "ErrorLogged"
   pattern        = "level=error"
@@ -223,6 +279,20 @@ resource "aws_cloudwatch_metric_alarm" "error_logged_warn" {
   alarm_description   = "This metric monitors for an error level logs"
 
   alarm_actions = [aws_sns_topic.alert_warning.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "error_logged_critical" {
+  alarm_name          = "ErrorLoggedCritical"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.error_logged.name
+  namespace           = "CovidShield"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "10"
+  alarm_description   = "This metric monitors for an error level logs"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
 }
 
 resource "aws_cloudwatch_log_metric_filter" "fatal_logged" {

--- a/config/terraform/aws/metrics.tf
+++ b/config/terraform/aws/metrics.tf
@@ -49,6 +49,34 @@ resource "aws_cloudwatch_log_metric_filter" "UnclaimedOneTimeCodeTotal" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "UnclaimedOneTimeCodeTotalWarn" {
+  alarm_name          = "UnclaimedOneTimeCodeTotalWarn"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.UnclaimedOneTimeCodeTotal.name
+  namespace           = "CovidShield"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "250"
+  alarm_description   = "This metric monitors for total unclaimed codes"
+
+  alarm_actions = [aws_sns_topic.alert_warning.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "UnclaimedOneTimeCodeTotalCritical" {
+  alarm_name          = "UnclaimedOneTimeCodeTotalCritical"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.UnclaimedOneTimeCodeTotal.name
+  namespace           = "CovidShield"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "400"
+  alarm_description   = "This metric monitors for total unclaimed codes"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
+}
+
 resource "aws_cloudwatch_log_metric_filter" "ClaimedOneTimeCodeTotal" {
   count = 8
 
@@ -63,6 +91,34 @@ resource "aws_cloudwatch_log_metric_filter" "ClaimedOneTimeCodeTotal" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "ClaimedOneTimeCodeTotalWarn" {
+  alarm_name          = "ClaimedOneTimeCodeTotalWarn"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.ClaimedOneTimeCodeTotal.name
+  namespace           = "CovidShield"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "3000"
+  alarm_description   = "This metric monitors for total claimed codes"
+
+  alarm_actions = [aws_sns_topic.alert_warning.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "ClaimedOneTimeCodeTotalCritical" {
+  alarm_name          = "ClaimedOneTimeCodeTotalCritical"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.ClaimedOneTimeCodeTotal.name
+  namespace           = "CovidShield"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "4500"
+  alarm_description   = "This metric monitors for total claimed codes"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
+}
+
 resource "aws_cloudwatch_log_metric_filter" "DiagnosisKeyTotal" {
   count = 8
 
@@ -75,4 +131,32 @@ resource "aws_cloudwatch_log_metric_filter" "DiagnosisKeyTotal" {
     namespace = "CovidShield"
     value     = "$.updates[${count.index}].sum"
   }
+}
+
+resource "aws_cloudwatch_metric_alarm" "DiagnosisKeyTotalWarn" {
+  alarm_name          = "DiagnosisKeyTotalWarn"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.DiagnosisKeyTotal.name
+  namespace           = "CovidShield"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "9000"
+  alarm_description   = "This metric monitors for total diagnosis keys"
+
+  alarm_actions = [aws_sns_topic.alert_warning.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "DiagnosisKeyTotalCritical" {
+  alarm_name          = "DiagnosisKeyTotalCritical"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.DiagnosisKeyTotal.name
+  namespace           = "CovidShield"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "13500"
+  alarm_description   = "This metric monitors for total diagnosis keys"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
 }

--- a/config/terraform/aws/metrics.tf
+++ b/config/terraform/aws/metrics.tf
@@ -53,7 +53,7 @@ resource "aws_cloudwatch_metric_alarm" "UnclaimedOneTimeCodeTotalWarn" {
   alarm_name          = "UnclaimedOneTimeCodeTotalWarn"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.UnclaimedOneTimeCodeTotal.name
+  metric_name         = "UnclaimedOneTimeCodeTotal"
   namespace           = "CovidShield"
   period              = "60"
   statistic           = "Sum"
@@ -67,7 +67,7 @@ resource "aws_cloudwatch_metric_alarm" "UnclaimedOneTimeCodeTotalCritical" {
   alarm_name          = "UnclaimedOneTimeCodeTotalCritical"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.UnclaimedOneTimeCodeTotal.name
+  metric_name         = "UnclaimedOneTimeCodeTotal"
   namespace           = "CovidShield"
   period              = "60"
   statistic           = "Sum"
@@ -95,7 +95,7 @@ resource "aws_cloudwatch_metric_alarm" "ClaimedOneTimeCodeTotalWarn" {
   alarm_name          = "ClaimedOneTimeCodeTotalWarn"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.ClaimedOneTimeCodeTotal.name
+  metric_name         = "ClaimedOneTimeCodeTotal"
   namespace           = "CovidShield"
   period              = "60"
   statistic           = "Sum"
@@ -109,7 +109,7 @@ resource "aws_cloudwatch_metric_alarm" "ClaimedOneTimeCodeTotalCritical" {
   alarm_name          = "ClaimedOneTimeCodeTotalCritical"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.ClaimedOneTimeCodeTotal.name
+  metric_name         = "ClaimedOneTimeCodeTotal"
   namespace           = "CovidShield"
   period              = "60"
   statistic           = "Sum"
@@ -137,7 +137,7 @@ resource "aws_cloudwatch_metric_alarm" "DiagnosisKeyTotalWarn" {
   alarm_name          = "DiagnosisKeyTotalWarn"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.DiagnosisKeyTotal.name
+  metric_name         = "DiagnosisKeyTotal"
   namespace           = "CovidShield"
   period              = "60"
   statistic           = "Sum"
@@ -151,7 +151,7 @@ resource "aws_cloudwatch_metric_alarm" "DiagnosisKeyTotalCritical" {
   alarm_name          = "DiagnosisKeyTotalCritical"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.DiagnosisKeyTotal.name
+  metric_name         = "DiagnosisKeyTotal"
   namespace           = "CovidShield"
   period              = "60"
   statistic           = "Sum"

--- a/config/terraform/aws/sns.tf
+++ b/config/terraform/aws/sns.tf
@@ -15,3 +15,25 @@ resource "aws_sns_topic" "alert_critical" {
     (var.billing_tag_key) = var.billing_tag_value
   }
 }
+
+resource "aws_sns_topic" "alert_warning_us_east" {
+  provider = aws.us-east-1
+
+  name              = "alert-warning"
+  kms_master_key_id = aws_kms_key.cw.arn
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}
+
+resource "aws_sns_topic" "alert_critical_us_east" {
+  provider = aws.us-east-1
+  
+  name              = "alert-critical"
+  kms_master_key_id = aws_kms_key.cw.arn
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}

--- a/config/terraform/aws/sns.tf
+++ b/config/terraform/aws/sns.tf
@@ -29,7 +29,7 @@ resource "aws_sns_topic" "alert_warning_us_east" {
 
 resource "aws_sns_topic" "alert_critical_us_east" {
   provider = aws.us-east-1
-  
+
   name              = "alert-critical"
   kms_master_key_id = aws_kms_key.cw.arn
 


### PR DESCRIPTION
Closes #204. 

This PR adds some more alerts for metrics:

- UnauthorizedNewOneTimeCodeRequests alerts critical at 100 occurrences in 5 minutes.
- UnauthorizedOneTimeCodeClaimRequests alerts critical at 100 occurrences in 5 minutes.
- UnauthorizedUploadRequests alerts critical at 100 occurrences in 5 minutes.
- 500Response alerts critical after 10 occurrences in 1 minute.
- ErrorLogged alerts critical after 10 occurrences in 1 minute.
- UnclaimedOneTimeCodeTotal alerts warn after 250 keys found in the DB.
- UnclaimedOneTimeCodeTotal alerts critical after 400 keys found in the DB.
- ClaimedOneTimeCodeTotal alerts warn after 3000 keys found in the DB.
- ClaimedOneTimeCodeTotal alerts critical after 4500 keys found in the DB.
- DiagnosisKeyTotal alerts warn after 9000 keys found in the DB.
- DiagnosisKeyTotal alerts critical after 13500 keys found in the DB.

To note is that these are baseline values and can be tuned. The initial key calculations were from the total number of daily cases in Canada.

