### PR TITLE
add more rate limit WAF rules and custom header for cloudfront

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -25,6 +25,7 @@ env:
   TF_VAR_rds_server_db_password: ${{ secrets.TF_VAR_rds_server_db_password }}
   TF_VAR_route53_zone_name: ${{ secrets.TF_VAR_route53_zone_name }}
   TF_VAR_new_key_claim_allow_list: ${{ secrets.TF_VAR_new_key_claim_allow_list }}
+  TF_VAR_cloudfront_custom_header: ${{ secrets.TF_VAR_cloudfront_custom_header }}
   TF_VAR_environment: ${{ secrets.TF_VAR_environment }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ defaultRetrievalServerPort: 8001
 defaultServerPort: 8010
 workerExpirationInterval: 30
 maxOneTimeCode: 1e8
-maxConsecutiveClaimKeyFailures: 8
+maxConsecutiveClaimKeyFailures: 50
 claimKeyBanDuration: 1
 
 # (Legal requirement: <21). We serve up the last 14. This number 15 includes the current day,

--- a/config/infrastructure/aws/README.md
+++ b/config/infrastructure/aws/README.md
@@ -51,12 +51,15 @@ aws ecs put-account-setting-default --name taskLongArnFormat --value enabled
 aws ecs put-account-setting-default --name containerInstanceLongArnFormat --value enabled
 ```
 
-All Terraform variables are defined in `config/terraform/aws/variables.tf` & their values are set in `config/terraform/aws/variables.auto.tfvars`. There are **four** secret variables that should be set through the following environment variables as to not commit plain text secrets to version control.
+All Terraform variables are defined in `config/terraform/aws/variables.tf` & their values are set in `config/terraform/aws/variables.auto.tfvars`. There are **seven** secret variables that should be set through the following environment variables as to not commit plain text secrets to version control.
 
 - `TF_VAR_ecs_task_key_retrieval_env_ecdsa_key`
 - `TF_VAR_ecs_task_key_retrieval_env_hmac_key`
 - `TF_VAR_ecs_task_key_submission_env_key_claim_token`
 - `TF_VAR_rds_backend_db_password`
+- `TF_VAR_cloudfront_custom_header`
+- `TF_VAR_environment`
+- `TF_VAR_new_key_claim_allow_list` (use ["0.0.0.0/1", "128.0.0.0/1"] for any)
 
 If you are using Terraform in Github actions the above can be set as Github secrets, and set as environment variables in your YAML file (see `.github/workflows/terraform.yml`).
 

--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -7,6 +7,12 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
     domain_name = aws_lb.covidshield_key_retrieval.dns_name
     origin_id   = aws_lb.covidshield_key_retrieval.name
 
+
+    custom_header {
+      name  = "covidshield"
+      value = var.cloudfront_custom_header
+    }
+
     custom_origin_config {
       http_port              = 80
       https_port             = 443
@@ -14,6 +20,7 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
       origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
+
 
   enabled         = true
   is_ipv6_enabled = true

--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -93,6 +93,11 @@ variable "termination_wait_time_in_minutes" {
   default     = 1
 }
 
+variable "cloudfront_custom_header" {
+  type        = string
+  description = "header to authenticate cloudfront to retrieval ALB"
+}
+
 # Task Key Submission
 variable "ecs_key_submission_name" {
   type = string

--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -10,7 +10,7 @@ resource "aws_wafv2_ip_set" "new_key_claim" {
 }
 
 ###
-# AWS WAF - Managed Rules
+# AWS WAF - Key Submission Rules
 ###
 resource "aws_wafv2_web_acl" "key_submission" {
   name  = "key_submission"
@@ -131,11 +131,11 @@ resource "aws_wafv2_web_acl" "key_submission" {
   }
 
   rule {
-    name     = "KeySubmissionClaimKeyURIRateLimit"
-    priority = 100
+    name     = "KeySubmissionClaimKeyURIRateLimit01"
+    priority = 101
 
     action {
-      count {}
+      block {}
     }
 
     statement {
@@ -164,7 +164,164 @@ resource "aws_wafv2_web_acl" "key_submission" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "KeySubmissionClaimKeyURIRateLimit"
+      metric_name                = "KeySubmissionClaimKeyURIRateLimit01"
+      sampled_requests_enabled   = true
+    }
+  }
+
+
+  rule {
+    name     = "KeySubmissionClaimKeyURIRateLimit02"
+    priority = 102
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 100
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          byte_match_statement {
+            positional_constraint = "EXACTLY"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/claim-key"
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KeySubmissionClaimKeyURIRateLimit02"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "KeySubmissionClaimKeyURIRateLimit03"
+    priority = 103
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 100
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          byte_match_statement {
+            positional_constraint = "EXACTLY"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/claim-key"
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KeySubmissionClaimKeyURIRateLimit03"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "KeySubmissionClaimKeyURIRateLimit04"
+    priority = 104
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 100
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          byte_match_statement {
+            positional_constraint = "EXACTLY"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/claim-key"
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KeySubmissionClaimKeyURIRateLimit04"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "KeySubmissionClaimKeyURIRateLimit05"
+    priority = 105
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 100
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          byte_match_statement {
+            positional_constraint = "EXACTLY"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/claim-key"
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KeySubmissionClaimKeyURIRateLimit05"
       sampled_requests_enabled   = true
     }
   }
@@ -325,12 +482,46 @@ resource "aws_wafv2_web_acl" "key_submission" {
   }
 }
 
+###
+# AWS WAF - Key Retrieval ALB Rules
+###
 resource "aws_wafv2_web_acl" "key_retrieval" {
   name  = "key_retrieval"
   scope = "REGIONAL"
 
   default_action {
-    allow {}
+    block {}
+  }
+
+  rule {
+    name     = "CloudFrontCustomHeader"
+    priority = 201
+
+    action {
+      allow {}
+    }
+
+    statement {
+      byte_match_statement {
+        positional_constraint = "EXACTLY"
+        field_to_match {
+          single_header {
+            name = "covidshield"
+          }
+        }
+        search_string = var.cloudfront_custom_header
+        text_transformation {
+          priority = 1
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "CloudFrontCustomHeader"
+      sampled_requests_enabled   = false
+    }
   }
 
   tags = {
@@ -339,11 +530,14 @@ resource "aws_wafv2_web_acl" "key_retrieval" {
 
   visibility_config {
     cloudwatch_metrics_enabled = true
-    metric_name                = "key_retrieval"
+    metric_name                = "CloudFrontCustomHeader"
     sampled_requests_enabled   = false
   }
 }
 
+###
+# AWS WAF - Key Retrieval CDN Rules
+###
 resource "aws_wafv2_web_acl" "key_retrieval_cdn" {
   provider = aws.us-east-1
 
@@ -352,6 +546,28 @@ resource "aws_wafv2_web_acl" "key_retrieval_cdn" {
 
   default_action {
     allow {}
+  }
+
+  rule {
+    name     = "KeyRetrievalRateLimit"
+    priority = 101
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 1000
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KeyRetrievalRateLimit"
+      sampled_requests_enabled   = true
+    }
   }
 
   tags = {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,7 +53,7 @@ func setDefaults() {
 	viper.SetDefault("defaultServerPort", 8010)
 	viper.SetDefault("workerExpirationInterval", 30)
 	viper.SetDefault("maxOneTimeCode", 1e8)
-	viper.SetDefault("maxConsecutiveClaimKeyFailures", 8)
+	viper.SetDefault("maxConsecutiveClaimKeyFailures", 50)
 	viper.SetDefault("claimKeyBanDuration", 1)
 	viper.SetDefault("maxDiagnosisKeyRetentionDays", 15)
 	viper.SetDefault("initialRemainingKeys", 28)

--- a/test/claim_key_test.rb
+++ b/test/claim_key_test.rb
@@ -6,15 +6,18 @@ class ClaimKeyTest < MiniTest::Test
   include(Helper::Include)
 
   def test_claim_key
+    config = get_app_config()
+    maxConsecutiveClaimKeyFailures = config["maxConsecutiveClaimKeyFailures"]
+    
     # too much post data
     resp = @sub_conn.post('/claim-key', 'a'*500)
     assert_response(resp, 400, 'application/x-protobuf')
-    assert_fields(resp, error: :UNKNOWN, server_public_key: nil, tries_remaining: 8)
+    assert_fields(resp, error: :UNKNOWN, server_public_key: nil, tries_remaining: maxConsecutiveClaimKeyFailures)
 
     # incomprehensible post data
     resp = @sub_conn.post('/claim-key', 'a'*100)
     assert_response(resp, 400, 'application/x-protobuf')
-    assert_fields(resp, error: :UNKNOWN, server_public_key: nil, tries_remaining: 8)
+    assert_fields(resp, error: :UNKNOWN, server_public_key: nil, tries_remaining: maxConsecutiveClaimKeyFailures)
 
     # invalid OneTimeCode
     kcq = Covidshield::KeyClaimRequest.new(
@@ -23,7 +26,7 @@ class ClaimKeyTest < MiniTest::Test
     )
     resp = @sub_conn.post('/claim-key', kcq.to_proto)
     assert_response(resp, 401, 'application/x-protobuf')
-    assert_fields(resp, error: :INVALID_ONE_TIME_CODE, server_public_key: nil, tries_remaining: 7, remaining_ban_duration: 0)
+    assert_fields(resp, error: :INVALID_ONE_TIME_CODE, server_public_key: nil, tries_remaining: maxConsecutiveClaimKeyFailures - 1, remaining_ban_duration: 0)
 
     # app_public_key too short
     kcq = Covidshield::KeyClaimRequest.new(
@@ -33,7 +36,7 @@ class ClaimKeyTest < MiniTest::Test
     resp = @sub_conn.post('/claim-key', kcq.to_proto)
     assert_response(resp, 400, 'application/x-protobuf')
     kcr = Covidshield::KeyClaimResponse.decode(resp.body)
-    assert_fields(resp, error: :INVALID_KEY, server_public_key: nil, tries_remaining: 7)
+    assert_fields(resp, error: :INVALID_KEY, server_public_key: nil, tries_remaining: maxConsecutiveClaimKeyFailures - 1)
 
     # app_public_key too short
     kcq = Covidshield::KeyClaimRequest.new(
@@ -43,7 +46,7 @@ class ClaimKeyTest < MiniTest::Test
     resp = @sub_conn.post('/claim-key', kcq.to_proto)
     assert_response(resp, 400, 'application/x-protobuf')
     kcr = Covidshield::KeyClaimResponse.decode(resp.body)
-    assert_fields(resp, error: :INVALID_KEY, server_public_key: nil, tries_remaining: 7)
+    assert_fields(resp, error: :INVALID_KEY, server_public_key: nil, tries_remaining: maxConsecutiveClaimKeyFailures - 1)
 
     # app_public_key too long
     kcq = Covidshield::KeyClaimRequest.new(
@@ -53,7 +56,7 @@ class ClaimKeyTest < MiniTest::Test
     resp = @sub_conn.post('/claim-key', kcq.to_proto)
     assert_response(resp, 400, 'application/x-protobuf')
     kcr = Covidshield::KeyClaimResponse.decode(resp.body)
-    assert_fields(resp, error: :INVALID_KEY, server_public_key: nil, tries_remaining: 7)
+    assert_fields(resp, error: :INVALID_KEY, server_public_key: nil, tries_remaining: maxConsecutiveClaimKeyFailures - 1)
 
     # happy path (this resets the tries_remaining)
     5.times do |i|
@@ -66,7 +69,7 @@ class ClaimKeyTest < MiniTest::Test
       kcr = Covidshield::KeyClaimResponse.decode(resp.body)
       assert_equal(:NONE, kcr.error)
       assert_equal(32, kcr.server_public_key.each_byte.size)
-      assert_equal(8, kcr.tries_remaining)
+      assert_equal(maxConsecutiveClaimKeyFailures, kcr.tries_remaining)
     end
 
     # app_public_key already exists
@@ -79,10 +82,12 @@ class ClaimKeyTest < MiniTest::Test
     kcr = Covidshield::KeyClaimResponse.decode(resp.body)
     assert_equal(:INVALID_KEY, kcr.error)
 
-    7.times do |i|
+    
+
+    (maxConsecutiveClaimKeyFailures - 1).times do |i|
       resp = post_invalid_otc!
       assert_response(resp, 401, 'application/x-protobuf')
-      assert_fields(resp, error: :INVALID_ONE_TIME_CODE, server_public_key: nil, tries_remaining: 8 - (1 + i), remaining_ban_duration: 0)
+      assert_fields(resp, error: :INVALID_ONE_TIME_CODE, server_public_key: nil, tries_remaining: maxConsecutiveClaimKeyFailures - (1 + i), remaining_ban_duration: 0)
     end
     # Now, let's get banned
     resp = post_invalid_otc!
@@ -118,7 +123,7 @@ class ClaimKeyTest < MiniTest::Test
     kcr = Covidshield::KeyClaimResponse.decode(resp.body)
     assert_equal(:NONE, kcr.error)
     assert_equal(32, kcr.server_public_key.each_byte.size)
-    assert_equal(8, kcr.tries_remaining)
+    assert_equal(maxConsecutiveClaimKeyFailures, kcr.tries_remaining)
   end
 
   def post_invalid_otc!

--- a/test/new_key_claim_hash_id_test.rb
+++ b/test/new_key_claim_hash_id_test.rb
@@ -6,6 +6,8 @@ class NewKeyClaimhashIDTest < MiniTest::Test
   include(Helper::Include)
 
   def test_new_key_claim
+    config = get_app_config()
+    maxConsecutiveClaimKeyFailures = config["maxConsecutiveClaimKeyFailures"]
     
     resp = @sub_conn.post do |req|
       req.url('/new-key-claim/abcd')
@@ -46,7 +48,7 @@ class NewKeyClaimhashIDTest < MiniTest::Test
     kcr = Covidshield::KeyClaimResponse.decode(resp.body)
     assert_equal(:NONE, kcr.error)
     assert_equal(32, kcr.server_public_key.each_byte.size)
-    assert_equal(8, kcr.tries_remaining)
+    assert_equal(maxConsecutiveClaimKeyFailures, kcr.tries_remaining)
 
     resp = @sub_conn.post do |req|
       req.url("/new-key-claim/#{hash_id}")


### PR DESCRIPTION
- add 5 rate limit rules of 100 requests / ip / 5min to submission endpoint
- add 1000 requests / ip / 5min rate limit rule to retrieval cloudfront distribution
- add a shared custom header between cloudfront and retrieval ALB endpoint so that requests can only come from cloudfront
- update README for new TF_VAR env vars

closes: #200 