### PR TITLE
block public access and expire WAF logs after 90 days

### DIFF
--- a/config/terraform/aws/s3.tf
+++ b/config/terraform/aws/s3.tf
@@ -11,5 +11,21 @@ resource "aws_s3_bucket" "firehose_waf_logs" {
       }
     }
   }
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 90
+    }
+  }
   #tfsec:ignore:AWS002
+}
+
+resource "aws_s3_bucket_public_access_block" "firehose_waf_logs" {
+  bucket = aws_s3_bucket.firehose_waf_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }


### PR DESCRIPTION
- blocks public access to WAF log s3 bucket
- expires WAF logs after 90 days